### PR TITLE
Fix typo: recorded_time -> wcroot_abstime

### DIFF
--- a/subvertpy/client.c
+++ b/subvertpy/client.c
@@ -1837,7 +1837,7 @@ static PyMemberDef wc_info_members[] = {
         "" },
     { "recorded_time", T_LONG, offsetof(WCInfoObject, info.recorded_time), READONLY,
         "" },
-    { "wcroot_abspath", T_STRING, offsetof(WCInfoObject, info.recorded_time), READONLY,
+    { "wcroot_abspath", T_STRING, offsetof(WCInfoObject, info.wcroot_abspath), READONLY,
         "" },
 #else
 #if ONLY_SINCE_SVN(1, 5)


### PR DESCRIPTION
The offset for wcroot_abspath is the same as the previous entry.