### PR TITLE
[python3] Open option ignore_keywords for export operation (since svn 1.7)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,5 +13,9 @@ Mac OS X support:
 Guillermo Gonzalez
 Jean-Francois Roy
 
+Python3 port:
+Martin Panter
+Yonggang Luo
+
 Name:
 Paul Hummer

--- a/INSTALL
+++ b/INSTALL
@@ -11,7 +11,7 @@ and Debian-based distributions such as Ubuntu is ``libsvn-dev``.
 Python
 ~~~~~~
 
-At least version 2.4 is required.
+At least version 3.1 is required.
 
 Building
 --------

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON = python
+PYTHON = python3
 PYDOCTOR = pydoctor
 SETUP = $(PYTHON) setup.py
 TESTRUNNER = unittest

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,7 @@
 PYTHON = python
 PYDOCTOR = pydoctor
 SETUP = $(PYTHON) setup.py
-ifeq ($(shell $(PYTHON) -c "import sys; print sys.version_info >= (2, 7)"),True)
 TESTRUNNER = unittest
-else
-TESTRUNNER = unittest2.__main__
-endif
 DEBUGGER ?=
 RUNTEST = PYTHONPATH=.:$(PYTHONPATH) $(DEBUGGER) $(PYTHON) -m $(TESTRUNNER)
 

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@
 
    * Support failing server certification check. (Mitsuhiro Koga, #1059821)
 
+  IMPROVEMENTS
+
+   * Add Python3 support (Martin Panter, Yonggang Luo).
+
 0.9.1	2013-05-06
 
  CHANGES

--- a/README
+++ b/README
@@ -18,11 +18,9 @@ much directly. Neither provide a hookable server-side.
 
 Dependencies
 ------------
-Subvertpy depends on Python 2.4 or later, and Subversion 1.4 or later. It should
-work on Windows as well as most POSIX-based platforms (including Linux, BSDs
-and Mac OS X).
-
-A port to Python 3 is planned but has not happened yet. Patches are welcome.
+This version of Subvertpy depends on Python 3.1 or later, and Subversion 1.4
+or later. It should work on Windows as well as most POSIX-based platforms
+(including Linux, BSDs and Mac OS X).
 
 Installation
 ------------

--- a/bin/subvertpy-fast-export
+++ b/bin/subvertpy-fast-export
@@ -124,9 +124,9 @@ def export_revision(rev, fs):
                     stream_length = len(stream.getvalue())
                 else:
                     if props.get("svn:executable", ""):
-                        mode = 0755
+                        mode = 0o755
                     else:
-                        mode = 0644
+                        mode = 0o644
                     stream_length = root.file_length(path)
                     stream = root.file_content(path)
                 file_changes.append("M %o :%s %s" % (

--- a/bin/subvertpy-fast-export
+++ b/bin/subvertpy-fast-export
@@ -218,7 +218,7 @@ if __name__ == '__main__':
 
     # Canonicalize (enough for Subversion, at least) the repository path.
     repos_path = os.path.normpath(args[0])
-    if repos_path == '.': 
+    if repos_path == '.':
         repos_path = ''
 
     try:

--- a/bin/subvertpy-fast-export
+++ b/bin/subvertpy-fast-export
@@ -15,7 +15,7 @@ branches_path = '/branches/'
 tags_path = '/tags/'
 address = 'localhost'
 
-from cStringIO import StringIO
+from io import BytesIO
 import sys, os.path
 from optparse import OptionParser
 import stat
@@ -120,7 +120,7 @@ def export_revision(rev, fs):
                         sys.stderr.write("special file '%s' is not a symlink, ignoring...\n" % path)
                         continue
                     mode = stat.S_IFLNK
-                    stream = StringIO(contents[len("link "):])
+                    stream = BytesIO(contents[len("link "):])
                     stream_length = len(stream.getvalue())
                 else:
                     if props.get("svn:executable", ""):

--- a/bin/subvertpy-fast-export
+++ b/bin/subvertpy-fast-export
@@ -174,7 +174,7 @@ def crawl_revisions(repos_path, first_rev=None, final_rev=None):
         first_rev = 1
     if final_rev is None:
         final_rev = fs_obj.youngest_revision()
-    for rev in xrange(first_rev, final_rev + 1):
+    for rev in range(first_rev, final_rev + 1):
         export_revision(rev, fs_obj)
 
 

--- a/bin/subvertpy-fast-export
+++ b/bin/subvertpy-fast-export
@@ -24,12 +24,13 @@ from time import mktime, strptime
 from subvertpy.repos import PATH_CHANGE_DELETE, Repository
 
 ct_short = ['M', 'A', 'D', 'R', 'X']
+stdout = sys.stdout.buffer
 
 def dump_file_blob(root, stream, stream_length):
-    sys.stdout.write("data %s\n" % stream_length)
-    sys.stdout.flush()
-    sys.stdout.write(stream.read())
-    sys.stdout.write("\n")
+    stdout.write(("data %s\n" % stream_length).encode("ascii"))
+    stdout.flush()
+    stdout.write(stream.read())
+    stdout.write(b"\n")
 
 
 class Matcher(object):
@@ -116,11 +117,11 @@ def export_revision(rev, fs):
                 marks[i] = MATCHER.replace(path)
                 if props.get("svn:special", ""):
                     contents = root.file_content(path).read()
-                    if not contents.startswith("link "):
+                    if not contents.startswith(b"link "):
                         sys.stderr.write("special file '%s' is not a symlink, ignoring...\n" % path)
                         continue
                     mode = stat.S_IFLNK
-                    stream = BytesIO(contents[len("link "):])
+                    stream = BytesIO(contents[len(b"link "):])
                     stream_length = len(stream.getvalue())
                 else:
                     if props.get("svn:executable", ""):
@@ -131,7 +132,7 @@ def export_revision(rev, fs):
                     stream = root.file_content(path)
                 file_changes.append("M %o :%s %s" % (
                     mode, i, marks[i].lstrip("/")))
-                sys.stdout.write("blob\nmark :%s\n" % i)
+                stdout.write(("blob\nmark :%s\n" % i).encode("ascii"))
                 dump_file_blob(root, stream, stream_length)
                 stream.close()
                 i += 1
@@ -151,13 +152,15 @@ def export_revision(rev, fs):
 
     svndate = props['svn:date'][0:-8]
     commit_time = mktime(strptime(svndate, '%Y-%m-%dT%H:%M:%S'))
-    sys.stdout.write("commit refs/heads/%s\n" % MATCHER.branchname())
-    sys.stdout.write("committer %s %s -0000\n" % (author, int(commit_time)))
-    sys.stdout.write("data %s\n" % len(props['svn:log']))
-    sys.stdout.write(props['svn:log'])
-    sys.stdout.write("\n")
-    sys.stdout.write('\n'.join(file_changes))
-    sys.stdout.write("\n\n")
+    line = "commit refs/heads/%s\n" % MATCHER.branchname()
+    stdout.write(line.encode("utf-8"))
+    line = "committer %s %s -0000\n" % (author, int(commit_time))
+    stdout.write(line.encode("utf-8"))
+    stdout.write(("data %s\n" % len(props['svn:log'])).encode("ascii"))
+    stdout.write(props['svn:log'].encode("utf-8"))
+    stdout.write(b"\n")
+    stdout.write(b'\n'.join(c.encode("utf-8") for c in file_changes))
+    stdout.write(b"\n\n")
     sys.stderr.write("done!\n")
 
 
@@ -220,12 +223,6 @@ if __name__ == '__main__':
     repos_path = os.path.normpath(args[0])
     if repos_path == '.':
         repos_path = ''
-
-    try:
-        import msvcrt
-        msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
-    except ImportError:
-        pass
 
     crawl_revisions(repos_path, first_rev=options.first_rev,
                     final_rev=options.final_rev)

--- a/bin/subvertpy-fast-export
+++ b/bin/subvertpy-fast-export
@@ -102,7 +102,7 @@ def export_revision(rev, fs):
     marks = {}
     file_changes = []
 
-    for path, (node_id, change_type, text_changed, prop_changed) in changes.iteritems():
+    for path, (node_id, change_type, text_changed, prop_changed) in changes.items():
         if root.is_dir(path):
             continue
         if not MATCHER.matches(path):

--- a/bin/subvertpy-fast-export
+++ b/bin/subvertpy-fast-export
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # svn-fast-export.py
 # ----------

--- a/examples/ra_commit.py
+++ b/examples/ra_commit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Demonstrates how to do a new commit using Subvertpy
 
 import os

--- a/examples/ra_commit.py
+++ b/examples/ra_commit.py
@@ -2,7 +2,7 @@
 # Demonstrates how to do a new commit using Subvertpy
 
 import os
-from cStringIO import StringIO
+from io import BytesIO
 from subvertpy import delta, repos
 from subvertpy.ra import RemoteAccess, Auth, get_username_provider
 
@@ -28,7 +28,7 @@ file = root.add_file("somefile")
 file.change_prop("svn:executable", "*")
 # Obtain a textdelta handler and send the new file contents
 txdelta = file.apply_textdelta()
-delta.send_stream(StringIO("new file contents"), txdelta)
+delta.send_stream(BytesIO(b"new file contents"), txdelta)
 file.close()
 root.close()
 editor.close()

--- a/examples/ra_log.py
+++ b/examples/ra_log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Demonstrates how to iterate over the log of a Subversion repository.
 
 from subvertpy.ra import RemoteAccess

--- a/examples/ra_log.py
+++ b/examples/ra_log.py
@@ -16,6 +16,6 @@ for (changed_paths, rev, revprops, has_children) in conn.iter_log(paths=None,
 
     print "Changed paths"
     for path, (action, from_path, from_rev, node_kind) in (
-            changed_paths.iteritems()):
+            changed_paths.items()):
         print "  %s (%s)" % (path, action)
 

--- a/examples/ra_log.py
+++ b/examples/ra_log.py
@@ -7,15 +7,15 @@ conn = RemoteAccess("svn://svn.samba.org/subvertpy/trunk")
 
 for (changed_paths, rev, revprops, has_children) in conn.iter_log(paths=None,
         start=0, end=conn.get_latest_revnum(), discover_changed_paths=True):
-    print "=" * 79
-    print "%d:" % rev
-    print "Revision properties:"
+    print("=" * 79)
+    print("%d:" % rev)
+    print("Revision properties:")
     for entry in revprops.items(): 
-        print "  %s: %s" % entry
-    print ""
+        print("  %s: %s" % entry)
+    print("")
 
-    print "Changed paths"
+    print("Changed paths")
     for path, (action, from_path, from_rev, node_kind) in (
             changed_paths.items()):
-        print "  %s (%s)" % (path, action)
+        print("  %s (%s)" % (path, action))
 

--- a/examples/ra_replay.py
+++ b/examples/ra_replay.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Demonstrates how to use the replay function to fetch the 
 # changes made in a revision.
 

--- a/examples/ra_replay.py
+++ b/examples/ra_replay.py
@@ -10,7 +10,7 @@ conn = RemoteAccess("svn://svn.gnome.org/svn/gnome-specimen/trunk",
 class MyFileEditor:
     
     def change_prop(self, key, value):
-        print "Change prop: %s -> %r" % (key, value)
+        print("Change prop: %s -> %r" % (key, value))
 
     def apply_textdelta(self, base_checksum):
         # This should return a function that can receive delta windows
@@ -24,26 +24,26 @@ class MyFileEditor:
 class MyDirEditor:
 
     def open_directory(self, *args):
-        print "Open dir: %s (base revnum: %r)" % args
+        print("Open dir: %s (base revnum: %r)" % args)
         return MyDirEditor()
 
     def add_directory(self, path, copyfrom_path=None, copyfrom_rev=-1):
-        print "Add dir: %s (from %r:%r)" % (path, copyfrom_path, copyfrom_rev)
+        print("Add dir: %s (from %r:%r)" % (path, copyfrom_path, copyfrom_rev))
         return MyDirEditor()
 
     def open_file(self, *args):
-        print "Open file: %s (base revnum: %r)" % args
+        print("Open file: %s (base revnum: %r)" % args)
         return MyFileEditor()
 
     def add_file(self, path, copyfrom_path=None, copyfrom_rev=-1):
-        print "Add file: %s (from %r:%r)" % (path, copyfrom_path, copyfrom_rev)
+        print("Add file: %s (from %r:%r)" % (path, copyfrom_path, copyfrom_rev))
         return MyFileEditor()
 
     def change_prop(self, key, value):
-        print "Change prop %s -> %r" % (key, value)
+        print("Change prop %s -> %r" % (key, value))
 
     def delete_entry(self, path, revision):
-        print "Delete: %s" % path
+        print("Delete: %s" % path)
 
     def close(self):
         pass
@@ -52,16 +52,16 @@ class MyDirEditor:
 class MyEditor:
 
     def set_target_revision(self, revnum):
-        print "Target revision: %d" % revnum
+        print("Target revision: %d" % revnum)
 
     def abort(self):
-        print "Aborted"
+        print("Aborted")
 
     def close(self):
-        print "Closed"
+        print("Closed")
 
     def open_root(self, base_revnum):
-        print "/"
+        print("/")
         return MyDirEditor()
 
 

--- a/examples/ra_shell.py
+++ b/examples/ra_shell.py
@@ -23,7 +23,7 @@ def log_printer(changed_paths, rev, revprops, has_children=None):
     if changed_paths is None:
         return
     print "Changed paths:"
-    for path, (action, from_path, from_rev) in changed_paths.iteritems():
+    for path, (action, from_path, from_rev) in changed_paths.items():
         print "  %s (%s)" % (path, action)
 
 
@@ -71,7 +71,7 @@ class RaCmd(cmd.Cmd):
         print conn.has_capability(args)
 
     def do_revprops(self, args):
-        for item in conn.rev_proplist(int(args)).iteritems():
+        for item in conn.rev_proplist(int(args)).items():
             print "%s: %s" % item
 
     def do_check_path(self, args):

--- a/examples/ra_shell.py
+++ b/examples/ra_shell.py
@@ -6,25 +6,25 @@ from subvertpy.ra import RemoteAccess
 import sys
 
 if len(sys.argv) == 1:
-    print "Usage: %s <url>" % sys.argv
+    print("Usage: %s <url>" % sys.argv)
 
 url = sys.argv[1]
 
 conn = RemoteAccess(url)
 
 def log_printer(changed_paths, rev, revprops, has_children=None):
-    print "=" * 79
-    print "%d:" % rev
-    print "Revision properties:"
+    print("=" * 79)
+    print("%d:" % rev)
+    print("Revision properties:")
     for entry in revprops.items(): 
-        print "  %s: %s" % entry
-    print ""
+        print("  %s: %s" % entry)
+    print("")
     
     if changed_paths is None:
         return
-    print "Changed paths:"
+    print("Changed paths:")
     for path, (action, from_path, from_rev) in changed_paths.items():
-        print "  %s (%s)" % (path, action)
+        print("  %s (%s)" % (path, action))
 
 
 class RaCmd(cmd.Cmd):
@@ -44,17 +44,17 @@ class RaCmd(cmd.Cmd):
     def do_help(self, args):
         for name in sorted(self.__class__.__dict__):
             if name.startswith("do_"):
-                print name[3:]
+                print(name[3:])
 
     def do_stat(self, args):
         path, revnum = self.parse_path_revnum(args)
-        print conn.stat(path, revnum)
+        print(conn.stat(path, revnum))
 
     def do_ls(self, args):
         path, revnum = self.parse_path_revnum(args)
         (dirents, fetched_rev, props) = conn.get_dir(path, revnum)
         for name in dirents:
-            print name
+            print(name)
 
     def do_cat(self, args):
         path, revnum = self.parse_path_revnum(args)
@@ -68,27 +68,27 @@ class RaCmd(cmd.Cmd):
         conn.change_rev_prop(int(revnum), name, value)
 
     def do_has_capability(self, args):
-        print conn.has_capability(args)
+        print(conn.has_capability(args))
 
     def do_revprops(self, args):
         for item in conn.rev_proplist(int(args)).items():
-            print "%s: %s" % item
+            print("%s: %s" % item)
 
     def do_check_path(self, args):
         path, revnum = self.parse_path_revnum(args)
         kind = conn.check_path(path, revnum)
         if kind == subvertpy.NODE_DIR:
-            print "dir"
+            print("dir")
         elif kind == subvertpy.NODE_FILE:
-            print "file"
+            print("file")
         else:
-            print "nonexistant"
+            print("nonexistant")
 
     def do_uuid(self, args):
-        print conn.get_uuid()
+        print(conn.get_uuid())
 
     def do_get_repos_root(self, args):
-        print conn.get_repos_root()
+        print(conn.get_repos_root())
 
     def do_log(self, args):
         conn.get_log(callback=log_printer, paths=None, start=0, 

--- a/examples/ra_shell.py
+++ b/examples/ra_shell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import cmd
 import subvertpy

--- a/examples/ra_shell.py
+++ b/examples/ra_shell.py
@@ -58,7 +58,7 @@ class RaCmd(cmd.Cmd):
 
     def do_cat(self, args):
         path, revnum = self.parse_path_revnum(args)
-        (fetched_rev, props) = conn.get_file(path, sys.stdout, revnum)
+        (fetched_rev, props) = conn.get_file(path, sys.stdout.buffer, revnum)
 
     def do_reparent(self, args):
         conn.reparent(args)

--- a/examples/wc.py
+++ b/examples/wc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Demonstrates how to do access the working tree using subvertpy
 
 import os

--- a/examples/wc.py
+++ b/examples/wc.py
@@ -12,7 +12,7 @@ c = client.Client(auth=Auth([get_username_provider()]))
 c.checkout("file://" + os.getcwd() + "/tmprepo", "tmpco", "HEAD")
 
 w = wc.WorkingCopy(None, "tmpco")
-print w
+print(w)
 entry = w.entry("tmpco")
-print entry.revision
-print entry.url
+print(entry.revision)
+print(entry.url)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Setup file for subvertpy
 # Copyright (C) 2005-2010 Jelmer Vernooij <jelmer@samba.org>
 

--- a/subvertpy/__init__.py
+++ b/subvertpy/__init__.py
@@ -127,7 +127,7 @@ try:
             from warnings import warn
             warn("subvertpy extensions are outdated and need to be rebuilt")
             break
-except ImportError, e:
+except ImportError as e:
     raise ImportError("Unable to load subvertpy extensions: %s" % e)
 
 

--- a/subvertpy/_ra.c
+++ b/subvertpy/_ra.c
@@ -481,7 +481,7 @@ static svn_error_t *py_get_client_string(void *baton, const char **name, apr_poo
 
 	CB_CHECK_PYRETVAL(ret);
 
-	*name = string_pstrdup(pool, ret);
+	*name = string_to_utf8(pool, ret);
 	Py_DECREF(ret);
 	PyGILState_Release(state);
 	if (*name == NULL) {
@@ -1318,7 +1318,7 @@ static PyObject *get_commit_editor(PyObject *self, PyObject *args, PyObject *kwa
 	
 	/* Copy in case the original string object gets deallocated before
 	the commit is finished. */
-	log_msg = string_pstrdup(pool, py_log_msg);
+	log_msg = string_to_utf8(pool, py_log_msg);
 	if (log_msg == NULL) {
 		goto fail_prep2;
 	}
@@ -1683,7 +1683,7 @@ static PyObject *ra_lock(PyObject *self, PyObject *args)
 		if (*rev == -1 && PyErr_Occurred()) {
 			goto fail_prep;
 		}
-		if (!string_pmemdup(temp_pool, k, &kbuffer, &ksize)) {
+		if (!string_to_utf8_and_size(temp_pool, k, &kbuffer, &ksize)) {
 			goto fail_prep;
 		}
 		apr_hash_set(hash_path_revs, kbuffer, ksize, rev);
@@ -2363,7 +2363,7 @@ static PyObject *auth_set_parameter(PyObject *self, PyObject *args)
 		*((apr_uint32_t *)vvalue) = ret;
 	} else if (!strcmp(name, SVN_AUTH_PARAM_DEFAULT_USERNAME) ||
 			   !strcmp(name, SVN_AUTH_PARAM_DEFAULT_PASSWORD)) {
-		vvalue = string_pstrdup(auth->pool, value);
+		vvalue = string_to_utf8(auth->pool, value);
 		if (vvalue == NULL) {
 			return NULL;
 		}
@@ -2668,7 +2668,7 @@ static svn_error_t *py_username_prompt(svn_auth_cred_username_t **cred, void *ba
 		goto fail;
 	}
 	
-	username = string_pstrdup(pool, py_username);
+	username = string_to_utf8(pool, py_username);
 	if (username == NULL) {
 		goto fail;
 	}
@@ -2912,7 +2912,7 @@ static svn_error_t *py_ssl_client_cert_pw_prompt(svn_auth_cred_ssl_client_cert_p
 		goto fail;
 	}
 	
-	password = string_pstrdup(pool, py_password);
+	password = string_to_utf8(pool, py_password);
 	if (password == NULL) {
 		goto fail;
 	}
@@ -2958,7 +2958,7 @@ static svn_error_t *py_ssl_client_cert_prompt(svn_auth_cred_ssl_client_cert_t **
 		PyErr_SetString(PyExc_TypeError, "cert_file should be string");
 		goto fail;
 	}
-	file = string_pstrdup(pool, py_cert_file);
+	file = string_to_utf8(pool, py_cert_file);
 	if (file == NULL) {
 		goto fail;
 	}

--- a/subvertpy/_ra.c
+++ b/subvertpy/_ra.c
@@ -811,8 +811,9 @@ static PyObject *ra_get_log(PyObject *self, PyObject *args, PyObject *kwargs)
 		"discover_changed_paths", "strict_node_history", "include_merged_revisions", "revprops", NULL };
 	PyObject *callback, *paths;
 	svn_revnum_t start = 0, end = 0;
-	int limit=0; 
-	bool discover_changed_paths=false, strict_node_history=true,include_merged_revisions=false;
+	int limit = 0; 
+	bool discover_changed_paths = false, strict_node_history = true;
+	bool include_merged_revisions = false;
 	RemoteAccessObject *ra = (RemoteAccessObject *)self;
 	PyObject *revprops = Py_None;
 	apr_pool_t *temp_pool;
@@ -826,7 +827,7 @@ static PyObject *ra_get_log(PyObject *self, PyObject *args, PyObject *kwargs)
 		return NULL;
 
 	if (!ra_get_log_prepare(ra, paths, include_merged_revisions,
-	revprops, &temp_pool, &apr_paths, &apr_revprops)) {
+			revprops, &temp_pool, &apr_paths, &apr_revprops)) {
 		return NULL;
 	}
 

--- a/subvertpy/_ra.c
+++ b/subvertpy/_ra.c
@@ -518,8 +518,8 @@ static svn_error_t *py_open_tmp_file(apr_file_t **fp, void *callback,
 
 	CB_CHECK_PYRETVAL(ret);
 
-	if (PyString_Check(ret)) {
-		char* fname = PyString_AsString(ret);
+	if (PyBytes_Check(ret)) {
+		char* fname = PyBytes_AsString(ret);
 		status = apr_file_open(fp, fname, APR_CREATE | APR_READ | APR_WRITE, APR_OS_DEFAULT, 
 								pool);
 		if (status) {
@@ -529,18 +529,13 @@ static svn_error_t *py_open_tmp_file(apr_file_t **fp, void *callback,
 			return py_svn_error();
 		}
 		Py_DECREF(ret);
-	} else if (PyFile_Check(ret)) {
+	} else {
 		*fp = apr_file_from_object(ret, pool);
 		Py_DECREF(ret);
 		if (!*fp) {
 			PyGILState_Release(state);
 			return py_svn_error();
 		}
-	} else {
-		PyErr_SetString(PyExc_TypeError, "Unknown type for file variable");
-		Py_DECREF(ret);
-		PyGILState_Release(state);
-		return py_svn_error();
 	}
 
 	PyGILState_Release(state);

--- a/subvertpy/_ra.c
+++ b/subvertpy/_ra.c
@@ -2515,7 +2515,7 @@ static PyTypeObject CredentialsIter_Type = {
 	NULL, /*	PyBufferProcs *tp_as_buffer;	*/
 
 	/* Flags to define presence of optional/expanded features */
-	Py_TPFLAGS_HAVE_ITER, /*	long tp_flags;	*/
+	0, /*	long tp_flags;	*/
 
 	NULL, /*	const char *tp_doc;  Documentation string */
 

--- a/subvertpy/_ra.c
+++ b/subvertpy/_ra.c
@@ -40,11 +40,11 @@
 
 static PyObject *busy_exc;
 
-staticforward PyTypeObject Reporter_Type;
-staticforward PyTypeObject RemoteAccess_Type;
-staticforward PyTypeObject AuthProvider_Type;
-staticforward PyTypeObject CredentialsIter_Type;
-staticforward PyTypeObject Auth_Type;
+static PyTypeObject Reporter_Type;
+static PyTypeObject RemoteAccess_Type;
+static PyTypeObject AuthProvider_Type;
+static PyTypeObject CredentialsIter_Type;
+static PyTypeObject Auth_Type;
 
 static bool ra_check_svn_path(char *path)
 {
@@ -294,7 +294,7 @@ static void reporter_dealloc(PyObject *self)
 }
 
 static PyTypeObject Reporter_Type = {
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"_ra.Reporter", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(ReporterObject), 
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -681,7 +681,7 @@ static PyObject *ra_get_uuid(PyObject *self)
 #else
 	RUN_RA_WITH_POOL(temp_pool, ra, svn_ra_get_uuid(ra->ra, &uuid, temp_pool));
 #endif
-	ret = PyString_FromString(uuid);
+	ret = PyUnicode_FromString(uuid);
 	apr_pool_destroy(temp_pool);
 	return ret;
 }
@@ -726,7 +726,7 @@ static PyObject *ra_get_latest_revnum(PyObject *self)
 	RUN_RA_WITH_POOL(temp_pool, ra,
 				  svn_ra_get_latest_revnum(ra->ra, &latest_revnum, temp_pool));
 	apr_pool_destroy(temp_pool);
-	return PyInt_FromLong(latest_revnum);
+	return PyLong_FromLong(latest_revnum);
 }
 
 
@@ -862,7 +862,7 @@ static PyObject *ra_get_repos_root(PyObject *self)
 		apr_pool_destroy(temp_pool);
 	}
 
-	return PyString_FromString(ra->root);
+	return PyUnicode_FromString(ra->root);
 }
 
 /**
@@ -884,7 +884,7 @@ static PyObject *ra_get_url(PyObject *self, void *closure)
 	RUN_RA_WITH_POOL(temp_pool, ra,
 						svn_ra_get_session_url(ra->ra, &url, temp_pool));
 
-	r = PyString_FromString(url);
+	r = PyUnicode_FromString(url);
 
 	apr_pool_destroy(temp_pool);
 
@@ -1298,7 +1298,7 @@ static PyObject *get_commit_editor(PyObject *self, PyObject *args, PyObject *kwa
 		goto fail_prep2;
 	}
 
-	if (!PyString_Check(py_log_msg)) {
+	if (!PyUnicode_Check(py_log_msg)) {
 		PyErr_SetString(PyExc_ValueError, "svn:log property should be set to string.");
 		goto fail_prep2;
 	}
@@ -1415,7 +1415,7 @@ static PyObject *ra_get_dir(PyObject *self, PyObject *args, PyObject *kwargs)
 				pykey = Py_None;
 				Py_INCREF(pykey);
 			} else {
-				pykey = PyString_FromString((char *)key);
+				pykey = PyUnicode_FromString((char *)key);
 				if (pykey == NULL) {
 					Py_DECREF(item);
 					goto fail_dirents;
@@ -1532,7 +1532,7 @@ static PyObject *ra_check_path(PyObject *self, PyObject *args)
 					  svn_ra_check_path(ra->ra, svn_path_canonicalize(path, temp_pool), revision, &kind, 
 					 temp_pool));
 	apr_pool_destroy(temp_pool);
-	return PyInt_FromLong(kind);
+	return PyLong_FromLong(kind);
 }
 
 static PyObject *ra_stat(PyObject *self, PyObject *args)
@@ -1654,7 +1654,7 @@ static PyObject *ra_lock(PyObject *self, PyObject *args)
 
 	while (PyDict_Next(path_revs, &idx, &k, &v)) {
 		rev = (svn_revnum_t *)apr_palloc(temp_pool, sizeof(svn_revnum_t));
-		*rev = PyInt_AsLong(v);
+		*rev = PyLong_AsLong(v);
 		if (*rev == -1 && PyErr_Occurred()) {
 			goto fail_prep;
 		}
@@ -1770,7 +1770,7 @@ static PyObject *ra_get_locations(PyObject *self, PyObject *args)
 		idx = apr_hash_next(idx)) {
 		apr_hash_this(idx, (const void **)&key, &klen, (void **)&val);
 		
-		py_val = PyString_FromString(val);
+		py_val = PyUnicode_FromString(val);
 		if (py_val == NULL) {
 			goto fail_conv;
 		}
@@ -2034,7 +2034,7 @@ static void ra_dealloc(PyObject *self)
 static PyObject *ra_repr(PyObject *self)
 {
 	RemoteAccessObject *ra = (RemoteAccessObject *)self;
-	return PyString_FromFormat("RemoteAccess(\"%s\")", ra->url);
+	return PyUnicode_FromFormat("RemoteAccess(\"%s\")", ra->url);
 }
 
 static int ra_set_progress_func(PyObject *self, PyObject *value, void *closure)
@@ -2165,7 +2165,7 @@ static PyMemberDef ra_members[] = {
 };
 
 static PyTypeObject RemoteAccess_Type = {
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"_ra.RemoteAccess", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(RemoteAccessObject), 
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -2252,7 +2252,7 @@ static void auth_provider_dealloc(PyObject *self)
 }
 
 static PyTypeObject AuthProvider_Type = {
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"_ra.AuthProvider", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(AuthProviderObject),
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -2329,7 +2329,7 @@ static PyObject *auth_set_parameter(PyObject *self, PyObject *args)
 		return NULL;
 
 	if (!strcmp(name, SVN_AUTH_PARAM_SSL_SERVER_FAILURES)) {
-		long ret = PyInt_AsLong(value);
+		long ret = PyLong_AsLong(value);
 		if (ret == -1 && PyErr_Occurred())
 			return NULL;
 		vvalue = apr_pcalloc(auth->pool, sizeof(apr_uint32_t));
@@ -2359,10 +2359,10 @@ static PyObject *auth_get_parameter(PyObject *self, PyObject *args)
 	value = svn_auth_get_parameter(auth->auth_baton, name);
 
 	if (!strcmp(name, SVN_AUTH_PARAM_SSL_SERVER_FAILURES)) {
-		return PyInt_FromLong(*((apr_uint32_t *)value));
+		return PyLong_FromLong(*((apr_uint32_t *)value));
 	} else if (!strcmp(name, SVN_AUTH_PARAM_DEFAULT_USERNAME) ||
 			   !strcmp(name, SVN_AUTH_PARAM_DEFAULT_PASSWORD)) {
-		return PyString_FromString((const char *)value);
+		return PyUnicode_FromString((const char *)value);
 	} else {
 		PyErr_Format(PyExc_TypeError, "Unsupported auth parameter %s", name);
 		return NULL;
@@ -2452,7 +2452,7 @@ static PyObject *credentials_iter_next(CredentialsIterObject *iterator)
 }
 
 static PyTypeObject CredentialsIter_Type = {
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"_ra.CredentialsIter", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(CredentialsIterObject),
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -2530,7 +2530,7 @@ static void auth_dealloc(PyObject *self)
 }
 
 static PyTypeObject Auth_Type = {
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"_ra.Auth", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(AuthObject),
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -2632,7 +2632,7 @@ static svn_error_t *py_username_prompt(svn_auth_cred_username_t **cred, void *ba
 	}
 	py_username = PyTuple_GetItem(ret, 0);
 	CB_CHECK_PYRETVAL(py_username);
-	if (!PyString_Check(py_username)) {
+	if (!PyUnicode_Check(py_username)) {
 		PyErr_SetString(PyExc_TypeError, "username should be string");
 		goto fail;
 	}
@@ -2697,14 +2697,14 @@ static svn_error_t *py_simple_prompt(svn_auth_cred_simple_t **cred, void *baton,
 
 	py_username = PyTuple_GetItem(ret, 0);
 	CB_CHECK_PYRETVAL(py_username);
-	if (!PyString_Check(py_username)) {
+	if (!PyUnicode_Check(py_username)) {
 		PyErr_SetString(PyExc_TypeError, "username should be string");
 		goto fail;
 	}
 
 	py_password = PyTuple_GetItem(ret, 1);
 	CB_CHECK_PYRETVAL(py_password);
-	if (!PyString_Check(py_password)) {
+	if (!PyUnicode_Check(py_password)) {
 		PyErr_SetString(PyExc_TypeError, "password should be string");
 		goto fail;
 	}
@@ -2784,7 +2784,7 @@ static svn_error_t *py_ssl_server_trust_prompt(svn_auth_cred_ssl_server_trust_t 
 	}
 
 	py_accepted_failures = PyTuple_GetItem(ret, 0);
-	if (!PyInt_Check(py_accepted_failures)) {
+	if (!PyLong_Check(py_accepted_failures)) {
 		Py_DECREF(ret);
 		PyErr_SetString(PyExc_TypeError, "accepted_failures should be integer");
 		PyGILState_Release(state);
@@ -2799,7 +2799,7 @@ static svn_error_t *py_ssl_server_trust_prompt(svn_auth_cred_ssl_server_trust_t 
 		return py_svn_error();
 	}
 
-	accepted_failures = PyInt_AsLong(py_accepted_failures);
+	accepted_failures = PyLong_AsLong(py_accepted_failures);
 	if (accepted_failures == -1 && PyErr_Occurred()) {
 		Py_DECREF(ret);
 		PyGILState_Release(state);
@@ -2855,7 +2855,7 @@ static svn_error_t *py_ssl_client_cert_pw_prompt(svn_auth_cred_ssl_client_cert_p
 		goto fail;
 	}
 	py_password = PyTuple_GetItem(ret, 0);
-	if (!PyString_Check(py_password)) {
+	if (!PyUnicode_Check(py_password)) {
 		PyErr_SetString(PyExc_TypeError, "password should be string");
 		goto fail;
 	}
@@ -2895,7 +2895,7 @@ static svn_error_t *py_ssl_client_cert_prompt(svn_auth_cred_ssl_client_cert_t **
 	}
 
 	py_cert_file = PyTuple_GetItem(ret, 0);
-	if (!PyString_Check(py_cert_file)) {
+	if (!PyUnicode_Check(py_cert_file)) {
 		PyErr_SetString(PyExc_TypeError, "cert_file should be string");
 		goto fail;
 	}
@@ -3099,7 +3099,7 @@ static PyObject *print_modules(PyObject *self)
 		apr_pool_destroy(pool);
 		return NULL;
 	}
-	ret = PyString_FromStringAndSize(string->data, string->len);
+	ret = PyUnicode_DecodeUTF8(string->data, string->len, NULL);
 	apr_pool_destroy(pool);
 	return ret;
 }
@@ -3274,51 +3274,55 @@ static PyMethodDef ra_module_methods[] = {
 	{ NULL, }
 };
 
-void init_ra(void)
+static struct PyModuleDef ra_module = {
+	PyModuleDef_HEAD_INIT, "_ra", "Remote Access", -1, ra_module_methods,
+};
+
+PyMODINIT_FUNC PyInit__ra(void)
 {
 	static apr_pool_t *pool;
-	PyObject *mod;
+	PyObject *mod = NULL;
 
 	if (PyType_Ready(&RemoteAccess_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&Editor_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&FileEditor_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&DirectoryEditor_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&Reporter_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&TxDeltaWindowHandler_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&Auth_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&CredentialsIter_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&AuthProvider_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&LogIterator_Type) < 0)
-		return;
+		return mod;
 
 	apr_initialize();
 	pool = Pool(NULL);
 	if (pool == NULL)
-		return;
+		return mod;
 	svn_ra_initialize(pool);
 	PyEval_InitThreads();
 
-	mod = Py_InitModule3("_ra", ra_module_methods, "Remote Access");
+	mod = PyModule_Create(&ra_module);
 	if (mod == NULL)
-		return;
+		return mod;
 
 	PyModule_AddObject(mod, "RemoteAccess", (PyObject *)&RemoteAccess_Type);
 	Py_INCREF(&RemoteAccess_Type);
@@ -3358,4 +3362,5 @@ void init_ra(void)
 #ifdef SVN_VER_REVISION
 	PyModule_AddIntConstant(mod, "SVN_REVISION", SVN_VER_REVISION);
 #endif
+	return mod;
 }

--- a/subvertpy/_ra.c
+++ b/subvertpy/_ra.c
@@ -765,10 +765,15 @@ apr_array_header_t **apr_paths, apr_array_header_t **apr_revprops)
 	} else {
 		int i;
 		for (i = 0; i < PySequence_Size(revprops); i++) {
-			const char *n = PyString_AsString(PySequence_GetItem(revprops, i));
-			if (strcmp(SVN_PROP_REVISION_LOG, n) && 
-				strcmp(SVN_PROP_REVISION_AUTHOR, n) &&
-				strcmp(SVN_PROP_REVISION_DATE, n)) {
+			PyObject *n = PySequence_GetItem(revprops, i);
+			if (!PyUnicode_Check(n)) {
+				PyErr_SetString(PyExc_TypeError,
+					"revprops items should be strings");
+				goto fail_prep;
+			}
+			if (PyUnicode_CompareWithASCIIString(n, SVN_PROP_REVISION_LOG) && 
+				PyUnicode_CompareWithASCIIString(n, SVN_PROP_REVISION_AUTHOR) &&
+				PyUnicode_CompareWithASCIIString(n, SVN_PROP_REVISION_DATE)) {
 				PyErr_SetString(PyExc_NotImplementedError, 
 								"fetching custom revision properties not supported");
 				goto fail_prep;

--- a/subvertpy/_ra.c
+++ b/subvertpy/_ra.c
@@ -1655,6 +1655,8 @@ static PyObject *ra_lock(PyObject *self, PyObject *args)
 	apr_pool_t *temp_pool;
 	apr_hash_t *hash_path_revs;
 	svn_revnum_t *rev;
+	apr_ssize_t ksize;
+	char *kbuffer;
 	Py_ssize_t idx = 0;
 
 	if (!PyArg_ParseTuple(args, "OsbO:lock", &path_revs, &comment, &steal_lock,
@@ -1679,8 +1681,10 @@ static PyObject *ra_lock(PyObject *self, PyObject *args)
 		if (*rev == -1 && PyErr_Occurred()) {
 			goto fail_prep;
 		}
-		apr_hash_set(hash_path_revs, PyString_AsString(k), PyString_Size(k), 
-					 rev);
+		if (!string_pmemdup(temp_pool, k, &kbuffer, &ksize)) {
+			goto fail_prep;
+		}
+		apr_hash_set(hash_path_revs, kbuffer, ksize, rev);
 	}
 	RUN_RA_WITH_POOL(temp_pool, ra, svn_ra_lock(ra->ra, hash_path_revs, comment, steal_lock,
 					 py_lock_func, lock_func, temp_pool));

--- a/subvertpy/_ra.c
+++ b/subvertpy/_ra.c
@@ -1270,12 +1270,11 @@ static PyObject *get_commit_editor(PyObject *self, PyObject *args, PyObject *kwa
 	if (lock_tokens == Py_None) {
 		hash_lock_tokens = NULL;
 	} else {
-		Py_ssize_t idx = 0;
-		PyObject *k, *v;
-		hash_lock_tokens = apr_hash_make(pool);
-		while (PyDict_Next(lock_tokens, &idx, &k, &v)) {
-			apr_hash_set(hash_lock_tokens, PyString_AsString(k), 
-						 PyString_Size(k), PyString_AsString(v));
+		/* Convert lock_tokens dict() to APR hash. Must keep strings
+		alive for the whole commit operation. */
+		hash_lock_tokens = string_dict_to_hash(pool, lock_tokens);
+		if (hash_lock_tokens == NULL) {
+			goto fail_prep;
 		}
 	}
 
@@ -1614,9 +1613,8 @@ static PyObject *ra_has_capability(PyObject *self, PyObject *args)
 static PyObject *ra_unlock(PyObject *self, PyObject *args)
 {
 	RemoteAccessObject *ra = (RemoteAccessObject *)self;
-	PyObject *path_tokens, *lock_func, *k, *v;
+	PyObject *path_tokens, *lock_func;
 	bool break_lock;
-	Py_ssize_t idx;
 	apr_pool_t *temp_pool;
 	apr_hash_t *hash_path_tokens;
 
@@ -1629,16 +1627,20 @@ static PyObject *ra_unlock(PyObject *self, PyObject *args)
 	temp_pool = Pool(NULL);
 	if (temp_pool == NULL)
 		goto fail_pool;
-	hash_path_tokens = apr_hash_make(temp_pool);
-	while (PyDict_Next(path_tokens, &idx, &k, &v)) {
-		apr_hash_set(hash_path_tokens, PyString_AsString(k), PyString_Size(k), (char *)PyString_AsString(v));
+	
+	hash_path_tokens = string_dict_to_hash(temp_pool, path_tokens);
+	if (hash_path_tokens == NULL) {
+		goto fail_prep;
 	}
+	
 	RUN_RA_WITH_POOL(temp_pool, ra, svn_ra_unlock(ra->ra, hash_path_tokens, break_lock,
 					 py_lock_func, lock_func, temp_pool));
 
 	apr_pool_destroy(temp_pool);
 	Py_RETURN_NONE;
 	
+fail_prep:
+	apr_pool_destroy(temp_pool);
 fail_pool:
 	ra->busy = false;
 fail_busy:

--- a/subvertpy/_ra_iter_log.c
+++ b/subvertpy/_ra_iter_log.c
@@ -114,7 +114,7 @@ static PyObject *py_iter_append(LogIteratorObject *iter, PyObject *tuple)
 }
 
 PyTypeObject LogIterator_Type = {
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"_ra.LogIterator", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(LogIteratorObject), 
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -146,7 +146,7 @@ PyTypeObject LogIterator_Type = {
 	NULL, /*	PyBufferProcs *tp_as_buffer;	*/
 	
 	/* Flags to define presence of optional/expanded features */
-	Py_TPFLAGS_HAVE_ITER, /*	long tp_flags;	*/
+	0, /*	long tp_flags;	*/
 	
 	NULL, /*	const char *tp_doc;  Documentation string */
 	

--- a/subvertpy/_ra_iter_log.c
+++ b/subvertpy/_ra_iter_log.c
@@ -230,7 +230,7 @@ static svn_error_t *py_iter_log_cb(void *baton, apr_hash_t *changed_paths, svn_r
 	state = PyGILState_Ensure();
 
 	if (!pyify_log_message(changed_paths, author, date, message, true,
-	pool, &py_changed_paths, &revprops)) {
+			pool, &py_changed_paths, &revprops)) {
 		goto fail;
 	}
 	tuple = Py_BuildValue("NlN", py_changed_paths, revision, revprops);
@@ -319,7 +319,7 @@ PyObject *ra_iter_log(PyObject *self, PyObject *args, PyObject *kwargs)
 		return NULL;
 
 	if (!ra_get_log_prepare(ra, paths, include_merged_revisions,
-	revprops, &pool, &apr_paths, &apr_revprops)) {
+			revprops, &pool, &apr_paths, &apr_revprops)) {
 		return NULL;
 	}
 

--- a/subvertpy/client.c
+++ b/subvertpy/client.c
@@ -85,14 +85,13 @@ static bool to_opt_revision(PyObject *arg, svn_opt_revision_t *ret)
         ret->kind = svn_opt_revision_unspecified;
         return true;
     } else if (PyUnicode_Check(arg)) {
-        char *text = PyString_AsString(arg);
-        if (!strcmp(text, "HEAD")) {
+        if (!PyUnicode_CompareWithASCIIString(arg, "HEAD")) {
             ret->kind = svn_opt_revision_head;
             return true;
-        } else if (!strcmp(text, "WORKING")) {
+        } else if (!PyUnicode_CompareWithASCIIString(arg, "WORKING")) {
             ret->kind = svn_opt_revision_working;
             return true;
-        } else if (!strcmp(text, "BASE")) {
+        } else if (!PyUnicode_CompareWithASCIIString(arg, "BASE")) {
             ret->kind = svn_opt_revision_base;
             return true;
         }

--- a/subvertpy/client.c
+++ b/subvertpy/client.c
@@ -656,16 +656,16 @@ static PyObject *client_commit(PyObject *self, PyObject *args, PyObject *kwargs)
 static PyObject *client_export(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     ClientObject *client = (ClientObject *)self;
-    char *kwnames[] = { "from", "to", "rev", "peg_rev", "recurse", "ignore_externals", "overwrite", "native_eol", NULL };
+    char *kwnames[] = { "from", "to", "rev", "peg_rev", "recurse", "ignore_externals", "overwrite", "native_eol", "ignore_keywords", NULL };
     svn_revnum_t result_rev;
     svn_opt_revision_t c_peg_rev, c_rev;
     char *from, *to;
     apr_pool_t *temp_pool;
 	char *native_eol = NULL;
     PyObject *peg_rev=Py_None, *rev=Py_None;
-    bool recurse=true, ignore_externals=false, overwrite=false;
+    bool recurse=true, ignore_externals=false, overwrite=false, ignore_keywords=false;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ss|OObbbb", kwnames, &from, &to, &rev, &peg_rev, &recurse, &ignore_externals, &overwrite, &native_eol))
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ss|OObbbbb", kwnames, &from, &to, &rev, &peg_rev, &recurse, &ignore_externals, &overwrite, &native_eol, &ignore_keywords))
         return NULL;
 
     if (!to_opt_revision(peg_rev, &c_peg_rev))
@@ -676,7 +676,13 @@ static PyObject *client_export(PyObject *self, PyObject *args, PyObject *kwargs)
     temp_pool = Pool(NULL);
     if (temp_pool == NULL)
         return NULL;
-#if ONLY_SINCE_SVN(1, 5)
+#if ONLY_SINCE_SVN(1, 7)
+    RUN_SVN_WITH_POOL(temp_pool, svn_client_export5(&result_rev, from,
+        svn_path_canonicalize(to, temp_pool),
+        &c_peg_rev, &c_rev, overwrite, ignore_externals, ignore_keywords,
+        recurse?svn_depth_infinity:svn_depth_files,
+        native_eol, client->client, temp_pool));
+#elif ONLY_SINCE_SVN(1, 5)
     RUN_SVN_WITH_POOL(temp_pool, svn_client_export4(&result_rev, from,
         svn_path_canonicalize(to, temp_pool),
         &c_peg_rev, &c_rev, overwrite, ignore_externals,

--- a/subvertpy/client.c
+++ b/subvertpy/client.c
@@ -75,16 +75,16 @@ static int client_set_config(PyObject *self, PyObject *auth, void *closure);
 
 static bool to_opt_revision(PyObject *arg, svn_opt_revision_t *ret)
 {
-    if (PyInt_Check(arg) || PyLong_Check(arg)) {
+    if (arg && PyLong_Check(arg)) {
         ret->kind = svn_opt_revision_number;
-        ret->value.number = PyInt_AsLong(arg);
+        ret->value.number = PyLong_AsLong(arg);
         if (ret->value.number == -1 && PyErr_Occurred())
             return false;
         return true;
     } else if (arg == Py_None) {
         ret->kind = svn_opt_revision_unspecified;
         return true;
-    } else if (PyString_Check(arg)) {
+    } else if (PyUnicode_Check(arg)) {
         char *text = PyString_AsString(arg);
         if (!strcmp(text, "HEAD")) {
             ret->kind = svn_opt_revision_head;
@@ -1605,7 +1605,7 @@ static PyObject *get_default_ignores(PyObject *self)
 	RUN_SVN_WITH_POOL(pool, svn_wc_get_default_ignores(&patterns, configobj->config, pool));
 	ret = PyList_New(patterns->nelts);
 	for (i = 0; i < patterns->nelts; i++) {
-		PyObject *item = PyString_FromString(APR_ARRAY_IDX(patterns, i, char *));
+		PyObject *item = PyUnicode_FromString(APR_ARRAY_IDX(patterns, i, char *));
 		if (item == NULL) {
 			apr_pool_destroy(pool);
 			Py_DECREF(item);
@@ -1638,7 +1638,7 @@ static void config_dealloc(PyObject *obj)
 }
 
 PyTypeObject Config_Type = {
-    PyObject_HEAD_INIT(NULL) 0,
+    PyVarObject_HEAD_INIT(NULL, 0)
     "client.Config", /*    const char *tp_name;  For printing, in format "<module>.<name>" */
     sizeof(ConfigObject),  /*  tp_basicsize    */
     0,  /*    tp_itemsize;  For allocation */
@@ -1706,7 +1706,7 @@ static void configitem_dealloc(PyObject *self)
 }
 
 PyTypeObject ConfigItem_Type = {
-    PyObject_HEAD_INIT(NULL) 0,
+    PyVarObject_HEAD_INIT(NULL, 0)
     "client.ConfigItem", /*    const char *tp_name;  For printing, in format "<module>.<name>" */
     sizeof(ConfigItemObject),
     0,/*    Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -1760,7 +1760,7 @@ static PyGetSetDef info_getsetters[] = {
 };
 
 PyTypeObject Info_Type = {
-    PyObject_HEAD_INIT(NULL) 0,
+    PyVarObject_HEAD_INIT(NULL, 0)
     "client.Info", /*   const char *tp_name;  For printing, in format "<module>.<name>" */
     sizeof(InfoObject),
     0,/*    Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -1860,7 +1860,7 @@ static void wcinfo_dealloc(PyObject *self)
 }
 
 PyTypeObject WCInfo_Type = {
-    PyObject_HEAD_INIT(NULL) 0,
+    PyVarObject_HEAD_INIT(NULL, 0)
     "client.Info", /*   const char *tp_name;  For printing, in format "<module>.<name>" */
     sizeof(WCInfoObject),
     0,/*    Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -1922,7 +1922,7 @@ PyTypeObject WCInfo_Type = {
 };
 
 PyTypeObject Client_Type = {
-    PyObject_HEAD_INIT(NULL) 0,
+    PyVarObject_HEAD_INIT(NULL, 0)
     /*    PyObject_VAR_HEAD    */
     "client.Client", /*    const char *tp_name;  For printing, in format "<module>.<name>" */
     sizeof(ClientObject),
@@ -2058,31 +2058,36 @@ static PyMethodDef client_mod_methods[] = {
 	{ NULL }
 };
 
-void initclient(void)
+static struct PyModuleDef client_mod = {
+	PyModuleDef_HEAD_INIT, "client", "Client methods", -1,
+	client_mod_methods,
+};
+
+PyMODINIT_FUNC PyInit_client(void)
 {
-    PyObject *mod;
+    PyObject *mod = NULL;
 
     if (PyType_Ready(&Client_Type) < 0)
-        return;
+        return mod;
 
     if (PyType_Ready(&Config_Type) < 0)
-        return;
+        return mod;
 
     if (PyType_Ready(&ConfigItem_Type) < 0)
-        return;
+        return mod;
 
     if (PyType_Ready(&Info_Type) < 0)
-        return;
+        return mod;
 
     if (PyType_Ready(&WCInfo_Type) < 0)
-        return;
+        return mod;
 
     /* Make sure APR is initialized */
     apr_initialize();
 
-    mod = Py_InitModule3("client", client_mod_methods, "Client methods");
+    mod = PyModule_Create(&client_mod);
     if (mod == NULL)
-        return;
+        return mod;
 
     Py_INCREF(&Client_Type);
     PyModule_AddObject(mod, "Client", (PyObject *)&Client_Type);
@@ -2098,4 +2103,5 @@ void initclient(void)
 
 	Py_INCREF(&Config_Type);
 	PyModule_AddObject(mod, "Config", (PyObject *)&Config_Type);
+	return mod;
 }

--- a/subvertpy/client.c
+++ b/subvertpy/client.c
@@ -273,7 +273,7 @@ static svn_error_t *info_receiver(void *dict, const char *path,
 static svn_error_t *py_log_msg_func2(const char **log_msg, const char **tmp_file, const apr_array_header_t *commit_items, void *baton, apr_pool_t *pool)
 {
     PyObject *py_commit_items, *ret, *py_log_msg, *py_tmp_file;
-    PyObject *bfile = NULL;
+    PyObject *blog = NULL, *bfile = NULL;
     PyGILState_STATE state;
 
     if (baton == Py_None)
@@ -294,25 +294,33 @@ static svn_error_t *py_log_msg_func2(const char **log_msg, const char **tmp_file
         py_log_msg = ret;
     }
     
+    if (py_log_msg != Py_None) {
+        blog = PyUnicode_AsUTF8String(py_log_msg);
+        if (blog == NULL) {
+            goto fail;
+        }
+    }
     if (py_tmp_file != Py_None) {
         if (!PyUnicode_FSConverter(py_tmp_file, &bfile)) {
             goto fail;
         }
     }
     
-    if (py_log_msg != Py_None) {
-        *log_msg = PyString_AsString(py_log_msg);
+    if (blog != NULL) {
+        *log_msg = apr_pstrdup(pool, PyBytes_AS_STRING(blog));
     }
     if (bfile != NULL) {
         *tmp_file = apr_pstrdup(pool, PyBytes_AS_STRING(bfile));
     }
     Py_XDECREF(bfile);
+    Py_XDECREF(blog);
     Py_DECREF(ret);
     PyGILState_Release(state);
     return NULL;
     
 fail:
     Py_XDECREF(bfile);
+    Py_XDECREF(blog);
     Py_DECREF(ret);
     PyGILState_Release(state);
     return py_svn_error();

--- a/subvertpy/client.c
+++ b/subvertpy/client.c
@@ -75,7 +75,7 @@ static int client_set_config(PyObject *self, PyObject *auth, void *closure);
 
 static bool to_opt_revision(PyObject *arg, svn_opt_revision_t *ret)
 {
-    if (arg && PyLong_Check(arg)) {
+    if (PyLong_Check(arg)) {
         ret->kind = svn_opt_revision_number;
         ret->value.number = PyLong_AsLong(arg);
         if (ret->value.number == -1 && PyErr_Occurred())

--- a/subvertpy/delta.py
+++ b/subvertpy/delta.py
@@ -114,7 +114,9 @@ def send_stream(stream, handler, block_size=DELTA_WINDOW_SIZE):
     """
     hash = md5()
     text = stream.read(block_size)
-    while text != "":
+    if not isinstance(text, bytes):
+        raise TypeError("The stream should read out bytes")
+    while text:
         hash.update(text)
         window = (0, 0, len(text), 0, [(TXDELTA_NEW, 0, len(text))], text)
         handler(window)

--- a/subvertpy/delta.py
+++ b/subvertpy/delta.py
@@ -97,7 +97,7 @@ def txdelta_apply_ops(src_ops, ops, new_data, sview):
             # Copy from source area.
             tview += sview[offset:offset+length]
         elif action == TXDELTA_TARGET:
-            for i in xrange(length):
+            for i in range(length):
                 tview += tview[offset+i]
         elif action == TXDELTA_NEW:
             tview += new_data[offset:offset+length]

--- a/subvertpy/delta.py
+++ b/subvertpy/delta.py
@@ -20,13 +20,9 @@ __docformat__ = "restructuredText"
 
 import sys
 
-if sys.version_info < (2, 5):
-    import md5 as _mod_md5
-    md5 = _mod_md5.new
-else:
-    from hashlib import (
-        md5,
-        )
+from hashlib import (
+    md5,
+    )
 
 
 TXDELTA_SOURCE = 0

--- a/subvertpy/delta.py
+++ b/subvertpy/delta.py
@@ -34,11 +34,11 @@ MAX_ENCODED_INT_LEN = 10
 
 DELTA_WINDOW_SIZE = 102400
 
-def apply_txdelta_window(sbuf,
-            (sview_offset, sview_len, tview_len, src_ops, ops, new_data)):
+def apply_txdelta_window(sbuf, window):
     """Apply a txdelta window to a buffer.
 
     :param sbuf: Source buffer (as bytestring)
+    :param window: (sview_offset, sview_len, tview_len, src_ops, ops, new_data)
     :param sview_offset: Offset of the source view
     :param sview_len: Length of the source view
     :param tview_len: Target view length
@@ -47,6 +47,7 @@ def apply_txdelta_window(sbuf,
     :param new_data: Buffer with possible new data
     :return: Target buffer
     """
+    (sview_offset, sview_len, tview_len, src_ops, ops, new_data) = window
     sview = sbuf[sview_offset:sview_offset+sview_len]
     tview = txdelta_apply_ops(src_ops, ops, new_data, sview)
     if len(tview) != tview_len:
@@ -172,14 +173,16 @@ def decode_length(text):
     return ret, text
 
 
-def pack_svndiff_instruction((action, offset, length)):
+def pack_svndiff_instruction(diff_params):
     """Pack a SVN diff instruction
 
+    :param diff_params: (action, offset, length)
     :param action: Action
     :param offset: Offset
     :param length: Length
     :return: encoded text
     """
+    (action, offset, length) = diff_params
     if length < 0x3f:
         text = chr((action << 6) + length)
     else:

--- a/subvertpy/delta.py
+++ b/subvertpy/delta.py
@@ -95,12 +95,12 @@ def txdelta_apply_ops(src_ops, ops, new_data, sview):
     for (action, offset, length) in ops:
         if action == TXDELTA_SOURCE:
             # Copy from source area.
-            tview += sview[offset:offset+length]
+            tview.extend(sview[offset:offset+length])
         elif action == TXDELTA_TARGET:
             for i in range(length):
-                tview += tview[offset+i]
+                tview.append(tview[offset+i])
         elif action == TXDELTA_NEW:
-            tview += new_data[offset:offset+length]
+            tview.extend(new_data[offset:offset+length])
         else:
             raise Exception("Invalid delta instruction code")
     return tview

--- a/subvertpy/editor.c
+++ b/subvertpy/editor.c
@@ -120,8 +120,11 @@ static PyObject *txdelta_call(PyObject *self, PyObject *args, PyObject *kwargs)
 	if (py_new_data == Py_None) {
 		window.new_data = NULL;
 	} else {
-		new_data.data = PyString_AsString(py_new_data);
-		new_data.len = PyString_Size(py_new_data);
+		Py_ssize_t sz;
+		if (PyBytes_AsStringAndSize(py_new_data, (char**)&new_data.data, (Py_ssize_t *)&sz) < 0) {
+			return NULL;
+		}
+		new_data.len = sz;
 		window.new_data = &new_data;
 	}
 
@@ -164,7 +167,7 @@ static void py_txdelta_window_handler_dealloc(PyObject *self)
 }
 
 PyTypeObject TxDeltaWindowHandler_Type = {
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"_ra.TxDeltaWindowHandler", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(TxDeltaWindowHandlerObject), 
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -302,7 +305,7 @@ static PyMethodDef py_file_editor_methods[] = {
 };
 
 PyTypeObject FileEditor_Type = { 
-	PyObject_HEAD_INIT(NULL) 0, 
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"_ra.FileEditor", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(EditorObject), 
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -677,7 +680,7 @@ static PyMethodDef py_dir_editor_methods[] = {
 };
 
 PyTypeObject DirectoryEditor_Type = { 
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"_ra.DirEditor", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(EditorObject), 
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -880,7 +883,7 @@ static PyMethodDef py_editor_methods[] = {
 };
 
 PyTypeObject Editor_Type = { 
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"_ra.Editor", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(EditorObject), 
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -1106,7 +1109,7 @@ svn_error_t *py_txdelta_window_handler(svn_txdelta_window_t *window, void *baton
 			}
 		}
 		if (window->new_data != NULL && window->new_data->data != NULL) {
-			py_new_data = PyString_FromStringAndSize(window->new_data->data,
+			py_new_data = PyBytes_FromStringAndSize(window->new_data->data,
 													 window->new_data->len);
 		} else {
 			py_new_data = Py_None;

--- a/subvertpy/marshall.py
+++ b/subvertpy/marshall.py
@@ -57,18 +57,18 @@ def marshall(x):
     :param x: Data item
     :return: encoded string
     """
-    if type(x) is int:
+    if isinstance(x, int):
         return "%d " % x
-    elif type(x) is list or type(x) is tuple:
+    elif isinstance(x, (list, tuple)):
         return "( " + "".join(map(marshall, x)) + ") "
     elif isinstance(x, literal):
         return "%s " % x
-    elif type(x) is str:
+    elif isinstance(x, bytes):
         return "%d:%s " % (len(x), x)
-    elif type(x) is unicode:
+    elif isinstance(x, str):
         x = x.encode("utf-8")
         return "%d:%s " % (len(x), x)
-    elif type(x) is bool:
+    elif isinstance(x, bool):
         if x == True:
             return "true "
         elif x == False:

--- a/subvertpy/marshall.py
+++ b/subvertpy/marshall.py
@@ -55,45 +55,45 @@ def marshall(x):
     """Marshall a Python data item.
     
     :param x: Data item
-    :return: encoded string
+    :return: encoded byte string
     """
     if isinstance(x, int):
-        return "%d " % x
+        return ("%d " % x).encode("ascii")
     elif isinstance(x, (list, tuple)):
-        return "( " + "".join(map(marshall, x)) + ") "
+        return b"( " + bytes().join(map(marshall, x)) + b") "
     elif isinstance(x, literal):
-        return "%s " % x
+        return ("%s " % x).encode("ascii")
     elif isinstance(x, bytes):
-        return "%d:%s " % (len(x), x)
+        return ("%d:" % len(x)).encode("ascii") + x + b" "
     elif isinstance(x, str):
         x = x.encode("utf-8")
-        return "%d:%s " % (len(x), x)
+        return ("%d:" % len(x)).encode("ascii") + x + b" "
     elif isinstance(x, bool):
         if x == True:
-            return "true "
+            return b"true "
         elif x == False:
-            return "false "
+            return b"false "
     raise MarshallError("Unable to marshall type %s" % x)
 
 
 def unmarshall(x):
-    """Unmarshall the next item from a text.
+    """Unmarshall the next item from a buffer.
 
-    :param x: Text to parse
-    :return: tuple with unpacked item and remaining text
+    :param x: Bytes to parse
+    :return: tuple with unpacked item and remaining bytes
     """
-    whitespace = ['\n', ' ']
+    whitespace = frozenset(b'\n ')
     if len(x) == 0:
         raise NeedMoreData("Not enough data")
-    if x[0] == "(": # list follows
+    if x[0] == ord(b"("): # list follows
         if len(x) <= 1:
             raise NeedMoreData("Missing whitespace")
-        if x[1] != " ": 
+        if x[1] != ord(b" "):
             raise MarshallError("missing whitespace after list start")
         x = x[2:]
         ret = []
         try:
-            while x[0] != ")":
+            while x[0] != ord(b")"):
                 (x, n) = unmarshall(x)
                 ret.append(n)
         except IndexError:
@@ -106,28 +106,28 @@ def unmarshall(x):
             raise MarshallError("Expected space, got '%c'" % x[1])
 
         return (x[2:], ret)
-    elif x[0].isdigit():
-        num = ""
+    elif x[:1].isdigit():
+        num = bytearray()
         # Check if this is a string or a number
-        while x[0].isdigit():
-            num += x[0]
+        while x[:1].isdigit():
+            num.append(x[0])
             x = x[1:]
         num = int(num)
 
         if x[0] in whitespace:
             return (x[1:], num)
-        elif x[0] == ":":
+        elif x[0] == ord(b":"):
             if len(x) < num:
                 raise NeedMoreData("Expected string of length %r" % num)
             return (x[num+2:], x[1:num+1])
         else:
             raise MarshallError("Expected whitespace or ':', got '%c'" % x[0])
-    elif x[0].isalpha():
-        ret = ""
+    elif x[:1].isalpha():
+        ret = bytearray()
         # Parse literal
         try:
-            while x[0].isalpha() or x[0].isdigit() or x[0] == '-':
-                ret += x[0]
+            while x[:1].isalpha() or x[:1].isdigit() or x[0] == ord(b'-'):
+                ret.append(x[0])
                 x = x[1:]
         except IndexError:
             raise NeedMoreData("Expected literal")
@@ -135,7 +135,7 @@ def unmarshall(x):
         if not x[0] in whitespace:
             raise MarshallError("Expected whitespace, got '%c'" % x[0])
 
-        return (x[1:], ret)
+        return (x[1:], ret.decode("ascii"))
     else:
         raise MarshallError("Unexpected character '%c'" % x[0])
 

--- a/subvertpy/properties.py
+++ b/subvertpy/properties.py
@@ -163,7 +163,7 @@ def generate_mergeinfo_property(merges):
         else:
             return "%d-%d%s" % (start, end, suffix)
     text = ""
-    for (path, ranges) in merges.iteritems():
+    for (path, ranges) in merges.items():
         assert path.startswith("/")
         text += "%s:%s\n" % (path, ",".join(map(formatrange, ranges)))
     return text
@@ -281,7 +281,7 @@ def diff(current, previous):
              with the old and the new property value.
     """
     ret = {}
-    for key, newval in current.iteritems():
+    for key, newval in current.items():
         oldval = previous.get(key)
         if oldval != newval:
             ret[key] = (oldval, newval)

--- a/subvertpy/properties.py
+++ b/subvertpy/properties.py
@@ -61,7 +61,7 @@ def time_from_cstring(text):
     assert usecstr[-1] == "Z"
     tm_usec = int(usecstr[:-1])
     tm = time.strptime(basestr, "%Y-%m-%dT%H:%M:%S")
-    return (long(calendar.timegm(tm)) * 1000000 + tm_usec)
+    return (int(calendar.timegm(tm)) * 1000000 + tm_usec)
 
 
 def parse_externals_description(base_url, val):

--- a/subvertpy/properties.py
+++ b/subvertpy/properties.py
@@ -18,7 +18,8 @@
 __author__ = "Jelmer Vernooij <jelmer@samba.org>"
 __docformat__ = "restructuredText"
 
-import bisect, calendar, time, urlparse
+import bisect, calendar, time
+from urllib.parse import urljoin
 
 
 class InvalidExternalsDescription(Exception):
@@ -117,7 +118,7 @@ def parse_externals_description(base_url, val):
             raise NotImplementedError("Relative to the scheme externals not yet supported")
         if relurl.startswith("^/"):
             raise NotImplementedError("Relative to the repository root externals not yet supported")
-        ret[path] = (revno, urlparse.urljoin(base_url+"/", relurl))
+        ret[path] = (revno, urljoin(base_url+"/", relurl))
     return ret
 
 

--- a/subvertpy/properties.py
+++ b/subvertpy/properties.py
@@ -152,7 +152,8 @@ def generate_mergeinfo_property(merges):
     :param merges: dictionary mapping paths to lists of ranges
     :return: Property contents
     """
-    def formatrange((start, end, inheritable)):
+    def formatrange(range_params):
+        (start, end, inheritable) = range_params
         suffix = ""
         if not inheritable:
             suffix = "*"

--- a/subvertpy/ra.py
+++ b/subvertpy/ra.py
@@ -23,7 +23,7 @@ from subvertpy import _ra
 from subvertpy._ra import *
 from subvertpy import ra_svn
 
-import urllib
+import urllib.parse
 
 url_handlers = {
         "svn": _ra.RemoteAccess,
@@ -43,7 +43,7 @@ def RemoteAccess(url, *args, **kwargs):
     """
     if isinstance(url, bytes):
         url = url.decode("utf-8")
-    (type, opaque) = urllib.splittype(url)
+    (type, opaque) = urllib.parse.splittype(url)
     if not type in url_handlers:
         raise SubversionException("Unknown URL type '%s'" % type, ERR_BAD_URL)
     return url_handlers[type](url, *args, **kwargs)

--- a/subvertpy/ra.py
+++ b/subvertpy/ra.py
@@ -41,6 +41,8 @@ def RemoteAccess(url, *args, **kwargs):
     :param url: URL to connect to
     :return: RemoteAccess object
     """
+    if isinstance(url, bytes):
+        url = url.decode("utf-8")
     (type, opaque) = urllib.splittype(url)
     if not type in url_handlers:
         raise SubversionException("Unknown URL type '%s'" % type, ERR_BAD_URL)

--- a/subvertpy/ra_svn.py
+++ b/subvertpy/ra_svn.py
@@ -22,8 +22,8 @@ import base64
 import os
 import socket
 import subprocess
-import urllib
 from errno import EPIPE
+import urllib.parse
 
 from subvertpy import (
     ERR_RA_SVN_UNKNOWN_CMD,
@@ -420,9 +420,9 @@ class SVNClient(SVNConnection):
     def __init__(self, url, progress_cb=None, auth=None, config=None, 
                  client_string_func=None, open_tmp_file_func=None):
         self.url = url
-        (type, opaque) = urllib.splittype(url)
+        (type, opaque) = urllib.parse.splittype(url)
         assert type in ("svn", "svn+ssh")
-        (host, path) = urllib.splithost(opaque)
+        (host, path) = urllib.parse.splithost(opaque)
         self._progress_cb = progress_cb
         self._auth = auth
         self._config = config
@@ -468,7 +468,7 @@ class SVNClient(SVNConnection):
     _recv_ack = _unpack
 
     def _connect(self, host):
-        (host, port) = urllib.splitnport(host, SVN_PORT)
+        (host, port) = urllib.parse.splitnport(host, SVN_PORT)
         sockaddrs = socket.getaddrinfo(host, port, socket.AF_UNSPEC,
                socket.SOCK_STREAM, 0, 0)
         self._socket = None
@@ -476,7 +476,7 @@ class SVNClient(SVNConnection):
             try:
                 self._socket = socket.socket(family, socktype, proto)
                 self._socket.connect(sockaddr)
-            except socket.error:
+            except socket.error as err:
                 if self._socket is not None:
                     self._socket.close()
                 self._socket = None
@@ -488,12 +488,12 @@ class SVNClient(SVNConnection):
         return (self._socket.recv, self._socket.send)
 
     def _connect_ssh(self, host):
-        (user, host) = urllib.splituser(host)
+        (user, host) = urllib.parse.splituser(host)
         if user is not None:
             (user, password) = urllib.splitpassword(user)
         else:
             password = None
-        (host, port) = urllib.splitnport(host, 22)
+        (host, port) = urllib.parse.splitnport(host, 22)
         self._tunnel = get_ssh_vendor().connect_ssh(user, password, host, port, ["svnserve", "-t"])
         return (self._tunnel.recv, self._tunnel.send)
 
@@ -916,7 +916,7 @@ class SVNServer(SVNConnection):
         self.send_success()
 
     def open_backend(self, url):
-        (rooturl, location) = urllib.splithost(url)
+        (rooturl, location) = urllib.parse.splithost(url)
         self.repo_backend, self.relpath = self.backend.open_repository(location)
 
     def reparent(self, parent):

--- a/subvertpy/ra_svn.py
+++ b/subvertpy/ra_svn.py
@@ -17,7 +17,7 @@
 
 __author__ = "Jelmer Vernooij <jelmer@samba.org>"
 
-import SocketServer
+import socketserver
 import base64
 import os
 import socket
@@ -1063,11 +1063,11 @@ class SVNServer(SVNConnection):
             self._logf.write("%s\n" % text)
 
 
-class TCPSVNRequestHandler(SocketServer.StreamRequestHandler):
+class TCPSVNRequestHandler(socketserver.StreamRequestHandler):
 
     def __init__(self, request, client_address, server):
         self._server = server
-        SocketServer.StreamRequestHandler.__init__(self, request, 
+        socketserver.StreamRequestHandler.__init__(self, request, 
             client_address, server)
 
     def handle(self):
@@ -1081,13 +1081,13 @@ class TCPSVNRequestHandler(SocketServer.StreamRequestHandler):
             raise
 
 
-class TCPSVNServer(SocketServer.TCPServer):
+class TCPSVNServer(socketserver.TCPServer):
 
     allow_reuse_address = True
-    serve = SocketServer.TCPServer.serve_forever
+    serve = socketserver.TCPServer.serve_forever
 
     def __init__(self, backend, addr, logf=None):
         self._logf = logf
         self._backend = backend
-        SocketServer.TCPServer.__init__(self, addr, TCPSVNRequestHandler)
+        socketserver.TCPServer.__init__(self, addr, TCPSVNRequestHandler)
 

--- a/subvertpy/ra_svn.py
+++ b/subvertpy/ra_svn.py
@@ -644,12 +644,12 @@ class SVNClient(SVNConnection):
                           keep_locks=False):
         args = [revprops[properties.PROP_REVISION_LOG]]
         if lock_tokens is not None:
-            args.append(lock_tokens.items())
+            args.append(list(lock_tokens.items()))
         else:
             args.append([])
         args.append(keep_locks)
         if len(revprops) > 1:
-            args.append(revprops.items())
+            args.append(list(revprops.items()))
         self.send_msg([literal("commit"), args])
         self._recv_ack()
         raise NotImplementedError(self.get_commit_editor)
@@ -895,7 +895,7 @@ class SVNServer(SVNConnection):
         def send_revision(revno, author, date, message, changed_paths=None):
             changes = []
             if changed_paths is not None:
-                for p, (action, cf, cr) in changed_paths.iteritems():
+                for p, (action, cf, cr) in changed_paths.items():
                     if cf is not None:
                         changes.append((p, literal(action), (cf, cr)))
                     else:
@@ -953,7 +953,7 @@ class SVNServer(SVNConnection):
     def rev_proplist(self, revnum):
         self.send_ack()
         revprops = self.repo_backend.rev_proplist(revnum)
-        self.send_success(revprops.items())
+        self.send_success(list(revprops.items()))
 
     def rev_prop(self, revnum, name):
         self.send_ack()
@@ -966,7 +966,7 @@ class SVNServer(SVNConnection):
     def get_locations(self, path, peg_revnum, revnums):
         self.send_ack()
         locations = self.repo_backend.get_locations(path, peg_revnum, revnums)
-        for rev, path in locations.iteritems():
+        for rev, path in locations.items():
             self.send_msg([rev, path])
         self.send_msg(literal("done"))
         self.send_success()

--- a/subvertpy/ra_svn.py
+++ b/subvertpy/ra_svn.py
@@ -476,7 +476,7 @@ class SVNClient(SVNConnection):
             try:
                 self._socket = socket.socket(family, socktype, proto)
                 self._socket.connect(sockaddr)
-            except socket.error, err:
+            except socket.error:
                 if self._socket is not None:
                     self._socket.close()
                 self._socket = None
@@ -1075,7 +1075,7 @@ class TCPSVNRequestHandler(SocketServer.StreamRequestHandler):
             self.wfile.write, self._server._logf)
         try:
             server.serve()
-        except socket.error, e:
+        except socket.error as e:
             if e.args[0] == EPIPE:
                 return
             raise

--- a/subvertpy/tests/__init__.py
+++ b/subvertpy/tests/__init__.py
@@ -270,7 +270,7 @@ class SubversionTestCase(TestCaseInTempDir):
         if recursive:
             return ret
         else:
-            return ret.values()[0]
+            return next(iter(ret.values()))
 
     def client_get_revprop(self, url, revnum, name):
         """Get the revision property.
@@ -372,7 +372,7 @@ class SubversionTestCase(TestCaseInTempDir):
         :param files: Dictionary with filenames as keys, contents as
             values. None as value indicates a directory.
         """
-        for name, content in files.iteritems():
+        for name, content in files.items():
             if content is None:
                 try:
                     os.makedirs(name)

--- a/subvertpy/tests/__init__.py
+++ b/subvertpy/tests/__init__.py
@@ -26,13 +26,7 @@ import stat
 import sys
 import tempfile
 import unittest
-try:
-    from unittest import SkipTest
-except ImportError:
-    try:
-        from unittest2 import SkipTest
-    except ImportError:
-        from testtools.testcase import TestSkipped as SkipTest
+from unittest import SkipTest
 import urllib2
 import urllib
 import urlparse

--- a/subvertpy/tests/__init__.py
+++ b/subvertpy/tests/__init__.py
@@ -19,7 +19,7 @@
 __author__ = 'Jelmer Vernooij <jelmer@samba.org>'
 __docformat__ = 'restructuredText'
 
-from cStringIO import StringIO
+from io import BytesIO
 import os
 import shutil
 import stat
@@ -112,7 +112,7 @@ class TestFileEditor(object):
         if contents is None:
             contents = urllib2.randombytes(100)
         txdelta = self.file.apply_textdelta()
-        delta.send_stream(StringIO(contents), txdelta)
+        delta.send_stream(BytesIO(contents), txdelta)
 
     def close(self):
         assert not self.is_closed

--- a/subvertpy/tests/__init__.py
+++ b/subvertpy/tests/__init__.py
@@ -249,7 +249,7 @@ class SubversionTestCase(TestCaseInTempDir):
                     f.write("#!/bin/sh\n")
                 finally:
                     f.close()
-                os.chmod(revprop_hook, os.stat(revprop_hook).st_mode | 0111)
+                os.chmod(revprop_hook, os.stat(revprop_hook).st_mode | 0o111)
 
         if sys.platform == 'win32':
             return 'file:%s' % urllib.pathname2url(abspath)

--- a/subvertpy/tests/__init__.py
+++ b/subvertpy/tests/__init__.py
@@ -383,7 +383,7 @@ class SubversionTestCase(TestCaseInTempDir):
                     os.makedirs(os.path.dirname(name))
                 except OSError:
                     pass
-                f = open(name, 'w')
+                f = open(name, 'wb')
                 try:
                     f.write(content)
                 finally:

--- a/subvertpy/tests/__init__.py
+++ b/subvertpy/tests/__init__.py
@@ -27,9 +27,8 @@ import sys
 import tempfile
 import unittest
 from unittest import SkipTest
-import urllib2
-import urllib
-import urlparse
+from urllib.request import pathname2url
+from urllib.parse import urljoin
 
 from subvertpy import (
     client,
@@ -104,7 +103,7 @@ class TestFileEditor(object):
 
     def modify(self, contents=None):
         if contents is None:
-            contents = urllib2.randombytes(100)
+            contents = os.urandom(100)
         txdelta = self.file.apply_textdelta()
         delta.send_stream(BytesIO(contents), txdelta)
 
@@ -154,7 +153,7 @@ class TestDirEditor(object):
     def add_dir(self, path, copyfrom_path=None, copyfrom_rev=-1):
         self.close_children()
         if copyfrom_path is not None:
-            copyfrom_path = urlparse.urljoin(self.baseurl+"/", copyfrom_path)
+            copyfrom_path = urljoin(self.baseurl+"/", copyfrom_path)
         if copyfrom_path is not None and copyfrom_rev == -1:
             copyfrom_rev = self.revnum
         assert (copyfrom_path is None and copyfrom_rev == -1) or \
@@ -167,7 +166,7 @@ class TestDirEditor(object):
     def add_file(self, path, copyfrom_path=None, copyfrom_rev=-1):
         self.close_children()
         if copyfrom_path is not None:
-            copyfrom_path = urlparse.urljoin(self.baseurl+"/", copyfrom_path)
+            copyfrom_path = urljoin(self.baseurl+"/", copyfrom_path)
         if copyfrom_path is not None and copyfrom_rev == -1:
             copyfrom_rev = self.revnum
         child = TestFileEditor(self.dir.add_file(path, copyfrom_path,
@@ -246,7 +245,7 @@ class SubversionTestCase(TestCaseInTempDir):
                 os.chmod(revprop_hook, os.stat(revprop_hook).st_mode | 0o111)
 
         if sys.platform == 'win32':
-            return 'file:%s' % urllib.pathname2url(abspath)
+            return 'file:%s' % pathname2url(abspath)
         else:
             return "file://%s" % abspath
 

--- a/subvertpy/tests/test_client.py
+++ b/subvertpy/tests/test_client.py
@@ -88,14 +88,14 @@ class TestClient(SubversionTestCase):
         self.client.mkdir("dc/bla", revprops={"svn:log": "foo"})
 
     def test_export(self):
-        self.build_tree({"dc/foo": "bla"})
+        self.build_tree({"dc/foo": b"bla"})
         self.client.add("dc/foo")
         self.client.commit(["dc"])
         self.client.export(self.repos_url, "de")
         self.assertEqual(["foo"], os.listdir("de"))
 
     def test_add_recursive(self):
-        self.build_tree({"dc/trunk/foo": 'bla', "dc/trunk": None})
+        self.build_tree({"dc/trunk/foo": b'bla', "dc/trunk": None})
         self.client.add("dc/trunk")
         if getattr(wc, "WorkingCopy", None) is None:
             raise SkipTest(
@@ -164,12 +164,12 @@ class TestClient(SubversionTestCase):
         self.assertEqual(value, io.getvalue())
 
     def test_cat(self):
-        self.build_tree({"dc/foo": "bla"})
+        self.build_tree({"dc/foo": b"bla"})
         self.client.add("dc/foo")
         self.client.log_msg_func = lambda c: "Commit"
         self.client.commit(["dc"])
         self.assertCatEquals(b"bla")
-        self.build_tree({"dc/foo": "blabla"})
+        self.build_tree({"dc/foo": b"blabla"})
         self.client.commit(["dc"])
         self.assertCatEquals(b"blabla")
         self.assertCatEquals(b"bla", revision=1)
@@ -199,7 +199,7 @@ class TestClient(SubversionTestCase):
                 'revprops': revprops,
                 'has_children': has_children,
             })
-        self.build_tree({"dc/foo": "bla"})
+        self.build_tree({"dc/foo": b"bla"})
         self.client.add("dc/foo")
         self.client.log_msg_func = lambda c: commit_msg_1
         self.client.commit(["dc"])
@@ -211,8 +211,8 @@ class TestClient(SubversionTestCase):
         self.assertLogEntryMessageEquals(commit_msg_1, log_entries[0])
         self.assertLogEntryDateAlmostEquals(commit_1_dt, log_entries[0], delta)
         self.build_tree({
-            "dc/foo": "blabla",
-            "dc/bar": "blablabla",
+            "dc/foo": b"blabla",
+            "dc/bar": b"blablabla",
         })
         self.client.add("dc/bar")
         self.client.log_msg_func = lambda c: commit_msg_2
@@ -238,7 +238,7 @@ class TestClient(SubversionTestCase):
         self.assertLogEntryDateAlmostEquals(commit_2_dt, log_entries[0], delta)
 
     def test_info(self):
-        self.build_tree({"dc/foo": "bla"})
+        self.build_tree({"dc/foo": b"bla"})
         self.client.add("dc/foo")
         self.client.log_msg_func = lambda c: "Commit"
         self.client.commit(["dc"])
@@ -249,11 +249,11 @@ class TestClient(SubversionTestCase):
         if client.api_version() < (1, 7):
             # TODO: Why is this failing on 1.7?
             self.assertEqual(wc.SCHEDULE_NORMAL, info["foo"].wc_info.schedule)
-        self.build_tree({"dc/bar": "blablabla"})
+        self.build_tree({"dc/bar": b"blablabla"})
         self.client.add(os.path.abspath("dc/bar"))
 
     def test_info_nonexistant(self):
-        self.build_tree({"dc/foo": "bla"})
+        self.build_tree({"dc/foo": b"bla"})
         self.client.add("dc/foo")
         self.client.log_msg_func = lambda c: "Commit"
         self.client.commit(["dc"])

--- a/subvertpy/tests/test_client.py
+++ b/subvertpy/tests/test_client.py
@@ -146,7 +146,7 @@ class TestClient(SubversionTestCase):
         (outf, errf) = self.client.diff(1, 2, self.repos_url, self.repos_url)
         self.addCleanup(outf.close)
         self.addCleanup(errf.close)
-        self.assertEqual("""Index: foo
+        self.assertEqual(b"""Index: foo
 ===================================================================
 --- foo\t(revision 1)
 +++ foo\t(revision 2)
@@ -156,7 +156,7 @@ class TestClient(SubversionTestCase):
 +foo2
 \\ No newline at end of file
 """, outf.read())
-        self.assertEqual("", errf.read())
+        self.assertEqual(b"", errf.read())
 
     def assertCatEquals(self, value, revision=None):
         io = StringIO()
@@ -168,12 +168,12 @@ class TestClient(SubversionTestCase):
         self.client.add("dc/foo")
         self.client.log_msg_func = lambda c: "Commit"
         self.client.commit(["dc"])
-        self.assertCatEquals("bla")
+        self.assertCatEquals(b"bla")
         self.build_tree({"dc/foo": "blabla"})
         self.client.commit(["dc"])
-        self.assertCatEquals("blabla")
-        self.assertCatEquals("bla", revision=1)
-        self.assertCatEquals("blabla", revision=2)
+        self.assertCatEquals(b"blabla")
+        self.assertCatEquals(b"bla", revision=1)
+        self.assertCatEquals(b"blabla", revision=2)
 
     def assertLogEntryChangedPathsEquals(self, expected, entry):
         changed_paths = entry["changed_paths"]

--- a/subvertpy/tests/test_client.py
+++ b/subvertpy/tests/test_client.py
@@ -243,7 +243,7 @@ class TestClient(SubversionTestCase):
         self.client.log_msg_func = lambda c: "Commit"
         self.client.commit(["dc"])
         info = self.client.info("dc/foo")
-        self.assertEqual(["foo"], info.keys())
+        self.assertEqual(["foo"], list(info.keys()))
         self.assertEqual(1, info["foo"].revision)
         self.assertEqual(3, info["foo"].size)
         if client.api_version() < (1, 7):

--- a/subvertpy/tests/test_client.py
+++ b/subvertpy/tests/test_client.py
@@ -155,7 +155,7 @@ class TestClient(SubversionTestCase):
 \\ No newline at end of file
 +foo2
 \\ No newline at end of file
-""", outf.read())
+""".splitlines(), outf.read().splitlines())
         self.assertEqual(b"", errf.read())
 
     def assertCatEquals(self, value, revision=None):

--- a/subvertpy/tests/test_client.py
+++ b/subvertpy/tests/test_client.py
@@ -17,7 +17,7 @@
 
 from datetime import datetime, timedelta
 import os
-from StringIO import StringIO
+from io import BytesIO
 import shutil
 import tempfile
 
@@ -130,12 +130,12 @@ class TestClient(SubversionTestCase):
                 auth=ra.Auth([ra.get_username_provider()]))
         dc = self.get_commit_editor(self.repos_url) 
         f = dc.add_file("foo")
-        f.modify("foo1")
+        f.modify(b"foo1")
         dc.close()
 
         dc = self.get_commit_editor(self.repos_url) 
         f = dc.open_file("foo")
-        f.modify("foo2")
+        f.modify(b"foo2")
         dc.close()
 
         if client.api_version() < (1, 5):
@@ -159,7 +159,7 @@ class TestClient(SubversionTestCase):
         self.assertEqual(b"", errf.read())
 
     def assertCatEquals(self, value, revision=None):
-        io = StringIO()
+        io = BytesIO()
         self.client.cat("dc/foo", io, revision)
         self.assertEqual(value, io.getvalue())
 

--- a/subvertpy/tests/test_client.py
+++ b/subvertpy/tests/test_client.py
@@ -245,7 +245,7 @@ class TestClient(SubversionTestCase):
         info = self.client.info("dc/foo")
         self.assertEqual(["foo"], info.keys())
         self.assertEqual(1, info["foo"].revision)
-        self.assertEqual(3L, info["foo"].size)
+        self.assertEqual(3, info["foo"].size)
         if client.api_version() < (1, 7):
             # TODO: Why is this failing on 1.7?
             self.assertEqual(wc.SCHEDULE_NORMAL, info["foo"].wc_info.schedule)

--- a/subvertpy/tests/test_client.py
+++ b/subvertpy/tests/test_client.py
@@ -94,6 +94,13 @@ class TestClient(SubversionTestCase):
         self.client.export(self.repos_url, "de")
         self.assertEqual(["foo"], os.listdir("de"))
 
+    def test_export_new_option(self):
+        self.build_tree({"dc/foo": b"bla"})
+        self.client.add("dc/foo")
+        self.client.commit(["dc"])
+        self.client.export(self.repos_url, "de", ignore_externals=True, ignore_keywords=True)
+        self.assertEqual(["foo"], os.listdir("de"))
+
     def test_add_recursive(self):
         self.build_tree({"dc/trunk/foo": b'bla', "dc/trunk": None})
         self.client.add("dc/trunk")

--- a/subvertpy/tests/test_delta.py
+++ b/subvertpy/tests/test_delta.py
@@ -38,7 +38,7 @@ class DeltaTests(TestCase):
         self.windows.append(window)
 
     def test_send_stream(self):
-        stream = BytesIO("foo")
+        stream = BytesIO(b"foo")
         send_stream(stream, self.storing_window_handler)
         self.assertEqual([(0, 0, 3, 0, [(2, 0, 3)], b'foo'), None], 
                           self.windows)

--- a/subvertpy/tests/test_delta.py
+++ b/subvertpy/tests/test_delta.py
@@ -15,7 +15,7 @@
 
 """Tests for subvertpy.delta."""
 
-from cStringIO import StringIO
+from io import BytesIO
 
 from subvertpy.delta import (
     decode_length,
@@ -38,28 +38,28 @@ class DeltaTests(TestCase):
         self.windows.append(window)
 
     def test_send_stream(self):
-        stream = StringIO("foo")
+        stream = BytesIO("foo")
         send_stream(stream, self.storing_window_handler)
         self.assertEqual([(0, 0, 3, 0, [(2, 0, 3)], b'foo'), None], 
                           self.windows)
-    
+
     def test_apply_delta(self):
-        stream = StringIO()
-        source = "(source)"
+        stream = BytesIO()
+        source = b"(source)"
         handler = apply_txdelta_handler(source, stream)
-        
-        new = "(new)"
+
+        new = b"(new)"
         ops = (  # (action, offset, length)
             (TXDELTA_NEW, 0, len(new)),
             (TXDELTA_SOURCE, 0, len(source)),
             (TXDELTA_TARGET, len(new), len("(s")),  # Copy "(s"
             (TXDELTA_TARGET, len("(n"), len("ew)")),  # Copy "ew)"
-            
+
             # Copy as target is generated
             (TXDELTA_TARGET, len(new + source), len("(sew)") * 2),
         )
         result = "(new)(source)(sew)(sew)(sew)"
-        
+
         # (source offset, source length, result length, src_ops, ops, new)
         handler((0, len(source), len(result), 0, ops, new))
         handler(None)

--- a/subvertpy/tests/test_delta.py
+++ b/subvertpy/tests/test_delta.py
@@ -69,12 +69,12 @@ class DeltaTests(TestCase):
 class MarshallTests(TestCase):
 
     def test_encode_length(self):
-        self.assertEqual("\x81\x02", encode_length(130))
+        self.assertEqual(bytes.fromhex("81 02"), encode_length(130))
 
     def test_roundtrip_length(self):
-        self.assertEqual((42, ""), decode_length(encode_length(42)))
+        self.assertEqual((42, bytes()), decode_length(encode_length(42)))
 
 
     def test_roundtrip_window(self):
-        mywindow = (0, 0, 3, 1, [(2, 0, 3)], 'foo')
+        mywindow = (0, 0, 3, 1, [(2, 0, 3)], b'foo')
         self.assertEqual([mywindow], list(unpack_svndiff0(pack_svndiff0([mywindow]))))

--- a/subvertpy/tests/test_delta.py
+++ b/subvertpy/tests/test_delta.py
@@ -52,13 +52,13 @@ class DeltaTests(TestCase):
         ops = (  # (action, offset, length)
             (TXDELTA_NEW, 0, len(new)),
             (TXDELTA_SOURCE, 0, len(source)),
-            (TXDELTA_TARGET, len(new), len("(s")),  # Copy "(s"
-            (TXDELTA_TARGET, len("(n"), len("ew)")),  # Copy "ew)"
+            (TXDELTA_TARGET, len(new), len(b"(s")),  # Copy "(s"
+            (TXDELTA_TARGET, len(b"(n"), len(b"ew)")),  # Copy "ew)"
 
             # Copy as target is generated
-            (TXDELTA_TARGET, len(new + source), len("(sew)") * 2),
+            (TXDELTA_TARGET, len(new + source), len(b"(sew)") * 2),
         )
-        result = "(new)(source)(sew)(sew)(sew)"
+        result = b"(new)(source)(sew)(sew)(sew)"
 
         # (source offset, source length, result length, src_ops, ops, new)
         handler((0, len(source), len(result), 0, ops, new))

--- a/subvertpy/tests/test_delta.py
+++ b/subvertpy/tests/test_delta.py
@@ -40,7 +40,7 @@ class DeltaTests(TestCase):
     def test_send_stream(self):
         stream = StringIO("foo")
         send_stream(stream, self.storing_window_handler)
-        self.assertEqual([(0, 0, 3, 0, [(2, 0, 3)], 'foo'), None], 
+        self.assertEqual([(0, 0, 3, 0, [(2, 0, 3)], b'foo'), None], 
                           self.windows)
     
     def test_apply_delta(self):

--- a/subvertpy/tests/test_marshall.py
+++ b/subvertpy/tests/test_marshall.py
@@ -43,53 +43,53 @@ class TestMarshalling(TestCase):
         self.assertEqual("bla bla", e.__str__())
     
     def test_marshall_int(self):
-        self.assertEqual("1 ", marshall(1))
+        self.assertEqual(b"1 ", marshall(1))
 
     def test_marshall_list(self):
-        self.assertEqual("( 1 2 3 4 ) ", marshall([1,2,3,4]))
+        self.assertEqual(b"( 1 2 3 4 ) ", marshall([1,2,3,4]))
     
     def test_marshall_list_mixed(self):
-        self.assertEqual("( 1 3 4 3:str ) ", marshall([1,3,4,"str"]))
+        self.assertEqual(b"( 1 3 4 3:str ) ", marshall([1,3,4,"str"]))
 
     def test_marshall_literal(self):
-        self.assertEqual("foo ", marshall(literal("foo")))
+        self.assertEqual(b"foo ", marshall(literal("foo")))
 
     def test_marshall_string(self):
-        self.assertEqual("3:foo ", marshall("foo"))
+        self.assertEqual(b"3:foo ", marshall("foo"))
 
     def test_marshall_raises(self):
         self.assertRaises(MarshallError, marshall, dict())
 
     def test_marshall_list_nested(self):
-        self.assertEqual("( ( ( 3 ) 4 ) ) ", marshall([[[3], 4]]))
+        self.assertEqual(b"( ( ( 3 ) 4 ) ) ", marshall([[[3], 4]]))
 
     def test_marshall_string_space(self):
-        self.assertEqual("5:bla l ", marshall("bla l"))
+        self.assertEqual(b"5:bla l ", marshall("bla l"))
 
     def test_unmarshall_string(self):
-        self.assertEqual(('', "bla l"), unmarshall("5:bla l"))
+        self.assertEqual((b'', b"bla l"), unmarshall(b"5:bla l"))
 
     def test_unmarshall_list(self):
-        self.assertEqual(('', [4,5]), unmarshall("( 4 5 ) "))
+        self.assertEqual((b'', [4,5]), unmarshall(b"( 4 5 ) "))
 
     def test_unmarshall_int(self):
-        self.assertEqual(('', 2), unmarshall("2 "))
+        self.assertEqual((b'', 2), unmarshall(b"2 "))
 
     def test_unmarshall_literal(self):
-        self.assertEqual(('', literal("x")), unmarshall("x "))
+        self.assertEqual((b'', literal("x")), unmarshall(b"x "))
 
     def test_unmarshall_empty(self):
-        self.assertRaises(MarshallError, unmarshall, "")
+        self.assertRaises(MarshallError, unmarshall, b"")
 
     def test_unmarshall_nospace(self):
-        self.assertRaises(MarshallError, unmarshall, "nospace")
+        self.assertRaises(MarshallError, unmarshall, b"nospace")
 
     def test_unmarshall_toolong(self):
-        self.assertRaises(MarshallError, unmarshall, "43432432:bla")
+        self.assertRaises(MarshallError, unmarshall, b"43432432:bla")
 
     def test_unmarshall_literal(self):
-        self.assertRaises(MarshallError, unmarshall, ":-3213")
+        self.assertRaises(MarshallError, unmarshall, b":-3213")
 
     def test_unmarshall_open_list(self):
-        self.assertRaises(MarshallError, unmarshall, "( 3 4 ")
+        self.assertRaises(MarshallError, unmarshall, b"( 3 4 ")
 

--- a/subvertpy/tests/test_properties.py
+++ b/subvertpy/tests/test_properties.py
@@ -29,7 +29,7 @@ class TestProperties(TestCase):
         super(TestProperties, self).setUp()
 
     def test_time_from_cstring(self):
-        self.assertEqual(1225704780716938L, properties.time_from_cstring("2008-11-03T09:33:00.716938Z"))
+        self.assertEqual(1225704780716938, properties.time_from_cstring("2008-11-03T09:33:00.716938Z"))
 
     def test_time_from_cstring_independent_from_dst(self):
         old_tz = os.environ.get('TZ', None)
@@ -42,7 +42,7 @@ class TestProperties(TestCase):
             os.environ['TZ'] = 'Europe/London'
             time.tzset()
             # Now test a time within that DST
-            self.assertEqual(1275295762430000L, properties.time_from_cstring("2010-05-31T08:49:22.430000Z"))
+            self.assertEqual(1275295762430000, properties.time_from_cstring("2010-05-31T08:49:22.430000Z"))
         finally:
             if old_tz is None:
                 del os.environ['TZ']
@@ -51,7 +51,7 @@ class TestProperties(TestCase):
             time.tzset()
 
     def test_time_to_cstring(self):
-        self.assertEqual("2008-11-03T09:33:00.716938Z", properties.time_to_cstring(1225704780716938L))
+        self.assertEqual("2008-11-03T09:33:00.716938Z", properties.time_to_cstring(1225704780716938))
 
 
 class TestExternalsParser(TestCase):

--- a/subvertpy/tests/test_ra.py
+++ b/subvertpy/tests/test_ra.py
@@ -329,12 +329,12 @@ class TestRemoteAccess(SubversionTestCase):
         stream = StringIO()
         self.ra.get_file("bar", stream, 1)
         stream.seek(0)
-        self.assertEqual("a", stream.read())
+        self.assertEqual(b"a", stream.read())
 
         stream = StringIO()
         self.ra.get_file("/bar", stream, 1)
         stream.seek(0)
-        self.assertEqual("a", stream.read())
+        self.assertEqual(b"a", stream.read())
 
     def test_get_locations_root(self):
         self.assertEqual({0: "/"}, self.ra.get_locations("", 0, [0]))

--- a/subvertpy/tests/test_ra.py
+++ b/subvertpy/tests/test_ra.py
@@ -281,7 +281,7 @@ class TestRemoteAccess(SubversionTestCase):
     def test_commit_file_props(self):
         cb = self.commit_editor()
         f = cb.add_file("bar")
-        f.modify("a")
+        f.modify(b"a")
         f.change_prop("bla:bar", "blie")
         cb.close()
 
@@ -299,12 +299,12 @@ class TestRemoteAccess(SubversionTestCase):
 
     def test_get_file_revs(self):
         cb = self.commit_editor()
-        cb.add_file("bar").modify("a")
+        cb.add_file("bar").modify(b"a")
         cb.close()
 
         cb = self.commit_editor()
         f = cb.open_file("bar")
-        f.modify("b")
+        f.modify(b"b")
         f.change_prop("bla", "bloe")
         cb.close()
 
@@ -323,7 +323,7 @@ class TestRemoteAccess(SubversionTestCase):
 
     def test_get_file(self):
         cb = self.commit_editor()
-        cb.add_file("bar").modify("a")
+        cb.add_file("bar").modify(b"a")
         cb.close()
 
         stream = BytesIO()

--- a/subvertpy/tests/test_ra.py
+++ b/subvertpy/tests/test_ra.py
@@ -15,7 +15,7 @@
 
 """Subversion ra library tests."""
 
-from cStringIO import StringIO
+from io import BytesIO
 
 from subvertpy import (
     NODE_DIR, NODE_NONE, NODE_UNKNOWN,
@@ -290,10 +290,10 @@ class TestRemoteAccess(SubversionTestCase):
         f.change_prop("bla:bar", None)
         cb.close()
 
-        stream = StringIO()
+        stream = BytesIO()
         props = self.ra.get_file("bar", stream, 1)[1]
         self.assertEqual("blie", props.get("bla:bar"))
-        stream = StringIO()
+        stream = BytesIO()
         props = self.ra.get_file("bar", stream, 2)[1]
         self.assertIs(None, props.get("bla:bar"))
 
@@ -326,12 +326,12 @@ class TestRemoteAccess(SubversionTestCase):
         cb.add_file("bar").modify("a")
         cb.close()
 
-        stream = StringIO()
+        stream = BytesIO()
         self.ra.get_file("bar", stream, 1)
         stream.seek(0)
         self.assertEqual(b"a", stream.read())
 
-        stream = StringIO()
+        stream = BytesIO()
         self.ra.get_file("/bar", stream, 1)
         stream.seek(0)
         self.assertEqual(b"a", stream.read())

--- a/subvertpy/tests/test_ra.py
+++ b/subvertpy/tests/test_ra.py
@@ -405,39 +405,39 @@ class AuthTests(TestCase):
     def test_simple(self):
         auth = ra.Auth([ra.get_simple_prompt_provider(lambda realm, uname, may_save: ("foo", "geheim", False), 0)])
         creds = auth.credentials("svn.simple", "MyRealm")
-        self.assertEqual(("foo", "geheim", 0), creds.next())
-        self.assertRaises(StopIteration, creds.next)
+        self.assertEqual(("foo", "geheim", 0), next(creds))
+        self.assertRaises(StopIteration, next, creds)
 
     def test_username(self):
         auth = ra.Auth([ra.get_username_prompt_provider(lambda realm, may_save: ("somebody", False), 0)])
         creds = auth.credentials("svn.username", "MyRealm")
-        self.assertEqual(("somebody", 0), creds.next())
-        self.assertRaises(StopIteration, creds.next)
+        self.assertEqual(("somebody", 0), next(creds))
+        self.assertRaises(StopIteration, next, creds)
 
     def test_client_cert(self):
         auth = ra.Auth([ra.get_ssl_client_cert_prompt_provider(lambda realm, may_save: ("filename", False), 0)])
         creds = auth.credentials("svn.ssl.client-cert", "MyRealm")
-        self.assertEqual(("filename", False), creds.next())
-        self.assertRaises(StopIteration, creds.next)
+        self.assertEqual(("filename", False), next(creds))
+        self.assertRaises(StopIteration, next, creds)
 
     def test_client_cert_pw(self):
         auth = ra.Auth([ra.get_ssl_client_cert_pw_prompt_provider(lambda realm, may_save: ("supergeheim", False), 0)])
         creds = auth.credentials("svn.ssl.client-passphrase", "MyRealm")
-        self.assertEqual(("supergeheim", False), creds.next())
-        self.assertRaises(StopIteration, creds.next)
+        self.assertEqual(("supergeheim", False), next(creds))
+        self.assertRaises(StopIteration, next, creds)
 
     def test_server_trust(self):
         auth = ra.Auth([ra.get_ssl_server_trust_prompt_provider(lambda realm, failures, certinfo, may_save: (42, False))])
         auth.set_parameter("svn:auth:ssl:failures", 23)
         creds = auth.credentials("svn.ssl.server", "MyRealm")
-        self.assertEqual((42, 0), creds.next())
-        self.assertRaises(StopIteration, creds.next)
+        self.assertEqual((42, 0), next(creds))
+        self.assertRaises(StopIteration, next, creds)
 
     def test_server_untrust(self):
         auth = ra.Auth([ra.get_ssl_server_trust_prompt_provider(lambda realm, failures, certinfo, may_save: None)])
         auth.set_parameter("svn:auth:ssl:failures", 23)
         creds = auth.credentials("svn.ssl.server", "MyRealm")
-        self.assertRaises(StopIteration, creds.next)
+        self.assertRaises(StopIteration, next, creds)
 
     def test_retry(self):
         self.i = 0
@@ -446,10 +446,10 @@ class AuthTests(TestCase):
             return ("somebody%d" % self.i, False)
         auth = ra.Auth([ra.get_username_prompt_provider(inc_foo, 2)])
         creds = auth.credentials("svn.username", "MyRealm")
-        self.assertEqual(("somebody1", 0), creds.next())
-        self.assertEqual(("somebody2", 0), creds.next())
-        self.assertEqual(("somebody3", 0), creds.next())
-        self.assertRaises(StopIteration, creds.next)
+        self.assertEqual(("somebody1", 0), next(creds))
+        self.assertEqual(("somebody2", 0), next(creds))
+        self.assertEqual(("somebody3", 0), next(creds))
+        self.assertRaises(StopIteration, next, creds)
 
     def test_set_default_username(self):
         a = ra.Auth([])

--- a/subvertpy/tests/test_ra.py
+++ b/subvertpy/tests/test_ra.py
@@ -159,7 +159,7 @@ class TestRemoteAccess(SubversionTestCase):
                 (paths, revnum, props, has_children) = returned[0]
             self.assertEqual(None, paths)
             self.assertEqual(revnum, 0)
-            self.assertEqual(["svn:date"], props.keys())
+            self.assertEqual(["svn:date"], list(props.keys()))
             if len(returned[1]) == 3:
                 (paths, revnum, props) = returned[1]
             else:
@@ -192,7 +192,7 @@ class TestRemoteAccess(SubversionTestCase):
                 (paths, revnum, props, has_children) = returned[0]
             self.assertEqual(None, paths)
             self.assertEqual(revnum, 0)
-            self.assertEqual(["svn:date"], props.keys())
+            self.assertEqual(["svn:date"], list(props.keys()))
             if len(returned[1]) == 3:
                 (paths, revnum, props) = returned[1]
             else:

--- a/subvertpy/tests/test_repos.py
+++ b/subvertpy/tests/test_repos.py
@@ -143,6 +143,6 @@ class StreamTests(TestCase):
 
     def test_write(self):
         s = repos.Stream()
-        self.assertEqual(0, s.write(""))
-        self.assertEqual(2, s.write("ab"))
+        self.assertEqual(0, s.write(b""))
+        self.assertEqual(2, s.write(b"ab"))
         s.close()

--- a/subvertpy/tests/test_repos.py
+++ b/subvertpy/tests/test_repos.py
@@ -15,7 +15,7 @@
 
 """Subversion repository library tests."""
 
-from cStringIO import StringIO
+from io import BytesIO
 import os
 import textwrap
 
@@ -52,7 +52,7 @@ class TestRepository(TestCaseInTempDir):
 
     def test_verify_fs(self):
         r = repos.create(os.path.join(self.test_dir, "foo"))
-        f = StringIO()
+        f = BytesIO()
         r.verify_fs(f, 0, 0)
         self.assertEqual(b'* Verified revision 0.\n', f.getvalue())
 
@@ -74,9 +74,9 @@ class TestRepository(TestCaseInTempDir):
 
     def test_load_fs_invalid(self):
         r = repos.create(os.path.join(self.test_dir, "foo"))
-        dumpfile = "Malformed"
-        feedback = StringIO()
-        self.assertRaises(SubversionException, r.load_fs, StringIO(dumpfile),
+        dumpfile = b"Malformed"
+        feedback = BytesIO()
+        self.assertRaises(SubversionException, r.load_fs, BytesIO(dumpfile),
             feedback, repos.LOAD_UUID_DEFAULT)
 
     def test_load_fs(self):
@@ -95,9 +95,9 @@ class TestRepository(TestCaseInTempDir):
         V 27
         2011-08-26T13:08:30.187858Z
         PROPS-END
-        """)
-        feedback = StringIO()
-        r.load_fs(StringIO(dumpfile), feedback, repos.LOAD_UUID_DEFAULT)
+        """).encode("ascii")
+        feedback = BytesIO()
+        r.load_fs(BytesIO(dumpfile), feedback, repos.LOAD_UUID_DEFAULT)
         self.assertEqual(r.fs().get_uuid(), "38f0a982-fd1f-4e00-aa6b-a20720f4b9ca")
 
     def test_rev_props(self):

--- a/subvertpy/tests/test_repos.py
+++ b/subvertpy/tests/test_repos.py
@@ -54,7 +54,7 @@ class TestRepository(TestCaseInTempDir):
         r = repos.create(os.path.join(self.test_dir, "foo"))
         f = StringIO()
         r.verify_fs(f, 0, 0)
-        self.assertEqual('* Verified revision 0.\n', f.getvalue())
+        self.assertEqual(b'* Verified revision 0.\n', f.getvalue())
 
     def test_open(self):
         repos.create(os.path.join(self.test_dir, "foo"))
@@ -137,8 +137,8 @@ class StreamTests(TestCase):
         if repos.api_version() < (1, 6):
             self.assertRaises(NotImplementedError, s.read)
         else:
-            self.assertEqual("", s.read())
-            self.assertEqual("", s.read(15))
+            self.assertEqual(b"", s.read())
+            self.assertEqual(b"", s.read(15))
         s.close()
 
     def test_write(self):

--- a/subvertpy/tests/test_repos.py
+++ b/subvertpy/tests/test_repos.py
@@ -102,7 +102,7 @@ class TestRepository(TestCaseInTempDir):
 
     def test_rev_props(self):
         repos.create(os.path.join(self.test_dir, "foo"))
-        self.assertEqual(["svn:date"], repos.Repository("foo").fs().revision_proplist(0).keys())
+        self.assertEqual(["svn:date"], list(repos.Repository("foo").fs().revision_proplist(0).keys()))
 
     def test_rev_root_invalid(self):
         repos.create(os.path.join(self.test_dir, "foo"))

--- a/subvertpy/tests/test_wc.py
+++ b/subvertpy/tests/test_wc.py
@@ -96,7 +96,7 @@ class AdmTests(SubversionTestCase):
 
     def test_has_binary_prop(self):
         repos_url = self.make_client("repos", "checkout")
-        self.build_tree({"checkout/bar": "\x00\x01"})
+        self.build_tree({"checkout/bar": bytes.fromhex("00 01")})
         self.client_add('checkout/bar')
         adm = wc.WorkingCopy(None, "checkout")
         path = os.path.join(self.test_dir, "checkout/bar")
@@ -105,7 +105,7 @@ class AdmTests(SubversionTestCase):
 
     def test_get_ancestry(self):
         repos_url = self.make_client("repos", "checkout")
-        self.build_tree({"checkout/bar": "\x00\x01"})
+        self.build_tree({"checkout/bar": bytes.fromhex("00 01")})
         self.client_add('checkout/bar')
         adm = wc.WorkingCopy(None, "checkout")
         path = os.path.join(self.test_dir, "checkout/bar")
@@ -126,7 +126,7 @@ class AdmTests(SubversionTestCase):
 
     def test_mark_missing_deleted(self):
         repos_url = self.make_client("repos", "checkout")
-        self.build_tree({"checkout/bar": "\x00\x01"})
+        self.build_tree({"checkout/bar": bytes.fromhex("00 01")})
         self.client_add('checkout/bar')
         adm = wc.WorkingCopy(None, "checkout", True)
         os.remove("checkout/bar")
@@ -135,7 +135,7 @@ class AdmTests(SubversionTestCase):
 
     def test_remove_from_revision_control(self):
         repos_url = self.make_client("repos", "checkout")
-        self.build_tree({"checkout/bar": "\x00\x01"})
+        self.build_tree({"checkout/bar": bytes.fromhex("00 01")})
         self.client_add('checkout/bar')
         adm = wc.WorkingCopy(None, "checkout", True)
         adm.remove_from_revision_control("bar")
@@ -148,7 +148,7 @@ class AdmTests(SubversionTestCase):
 
     def test_translated_stream(self):
         repos_url = self.make_client("repos", "checkout")
-        self.build_tree({"checkout/bar": "My id: $Id$"})
+        self.build_tree({"checkout/bar": b"My id: $Id$"})
         self.client_add('checkout/bar')
         self.client_set_prop("checkout/bar", "svn:keywords", "Id\n")
         self.client_commit("checkout", "foo")
@@ -159,18 +159,18 @@ class AdmTests(SubversionTestCase):
 
     def test_text_modified(self):
         repos_url = self.make_client("repos", "checkout")
-        self.build_tree({"checkout/bar": "My id: $Id$"})
+        self.build_tree({"checkout/bar": b"My id: $Id$"})
         self.client_add('checkout/bar')
         self.client_set_prop("checkout/bar", "svn:keywords", "Id\n")
         self.client_commit("checkout", "foo")
         adm = wc.WorkingCopy(None, "checkout")
         self.assertFalse(adm.text_modified("checkout/bar"))
-        self.build_tree({"checkout/bar": "gambon"})
+        self.build_tree({"checkout/bar": b"gambon"})
         self.assertTrue(adm.text_modified("checkout/bar", True))
 
     def test_props_modified(self):
         repos_url = self.make_client("repos", "checkout")
-        self.build_tree({"checkout/bar": "My id: $Id$"})
+        self.build_tree({"checkout/bar": b"My id: $Id$"})
         self.client_add('checkout/bar')
         self.client_set_prop("checkout/bar", "svn:keywords", "Id\n")
         self.client_commit("checkout", "foo")
@@ -181,7 +181,7 @@ class AdmTests(SubversionTestCase):
 
     def test_prop_set(self):
         repos_url = self.make_client("repos", "checkout")
-        self.build_tree({"checkout/bar": "file"})
+        self.build_tree({"checkout/bar": b"file"})
         self.client_add('checkout/bar')
         adm = wc.WorkingCopy(None, "checkout", True)
         adm.prop_set("aprop", "avalue", "checkout/bar")
@@ -204,7 +204,7 @@ class AdmTests(SubversionTestCase):
 
     def test_entry(self):
         repos_url = self.make_client("repos", "checkout")
-        self.build_tree({"checkout/bar": "\x00\x01"})
+        self.build_tree({"checkout/bar": bytes.fromhex("00 01")})
         self.client_add('checkout/bar')
         adm = wc.WorkingCopy(None, "checkout")
         entry = adm.entry("checkout/bar")
@@ -233,7 +233,7 @@ class AdmTests(SubversionTestCase):
 
     def test_status(self):
         repos_url = self.make_client("repos", "checkout")
-        self.build_tree({"checkout/bar": "text"})
+        self.build_tree({"checkout/bar": b"text"})
         self.client_add('checkout/bar')
         adm = wc.WorkingCopy(None, "checkout")
         self.assertEqual(wc.STATUS_ADDED, adm.status('bar').status)
@@ -243,7 +243,7 @@ class AdmTests(SubversionTestCase):
 
     def test_transmit_text_deltas(self):
         repos_url = self.make_client("repos", ".")
-        self.build_tree({"bar": "blala"})
+        self.build_tree({"bar": b"blala"})
         self.client_add('bar')
         adm = wc.WorkingCopy(None, ".", True)
         class Editor(object):
@@ -282,7 +282,7 @@ class AdmTests(SubversionTestCase):
 
     def test_process_committed_queue(self):
         repos_url = self.make_client("repos", "checkout")
-        self.build_tree({"checkout/bar": "la"})
+        self.build_tree({"checkout/bar": b"la"})
         self.client_add('checkout/bar')
         adm = wc.WorkingCopy(None, "checkout", True)
         cq = wc.CommittedQueue()
@@ -295,7 +295,7 @@ class AdmTests(SubversionTestCase):
 
     def test_probe_try(self):
         repos_url = self.make_client("repos", "checkout")
-        self.build_tree({"checkout/bar": "la"})
+        self.build_tree({"checkout/bar": b"la"})
         self.client_add('checkout/bar')
         adm = wc.WorkingCopy(None, "checkout", True)
         try:

--- a/subvertpy/tests/test_wc.py
+++ b/subvertpy/tests/test_wc.py
@@ -15,7 +15,7 @@
 
 """Subversion ra library tests."""
 
-from StringIO import StringIO
+from io import BytesIO
 import os
 
 import subvertpy
@@ -121,7 +121,7 @@ class AdmTests(SubversionTestCase):
     def test_add_repos_file(self):
         repos_url = self.make_client("repos", "checkout")
         adm = wc.WorkingCopy(None, "checkout", True)
-        adm.add_repos_file("checkout/bar", StringIO("basecontents"), StringIO("contents"), {}, {})
+        adm.add_repos_file("checkout/bar", BytesIO(b"basecontents"), BytesIO(b"contents"), {}, {})
         self.assertEqual(b"basecontents", wc.get_pristine_contents("checkout/bar").read())
 
     def test_mark_missing_deleted(self):

--- a/subvertpy/tests/test_wc.py
+++ b/subvertpy/tests/test_wc.py
@@ -300,7 +300,8 @@ class AdmTests(SubversionTestCase):
         adm = wc.WorkingCopy(None, "checkout", True)
         try:
             self.assertIs(None, adm.probe_try(self.test_dir))
-        except subvertpy.SubversionException, (msg, num):
+        except subvertpy.SubversionException as e:
+            (msg, num) = e.args
             if num != subvertpy.ERR_WC_NOT_WORKING_COPY:
                 raise
         self.assertEqual("checkout", adm.probe_try(os.path.join("checkout", "bar")).access_path())

--- a/subvertpy/tests/test_wc.py
+++ b/subvertpy/tests/test_wc.py
@@ -261,7 +261,7 @@ class AdmTests(SubversionTestCase):
                 pass
         editor = Editor()
         (tmpfile, digest) = adm.transmit_text_deltas("bar", True, editor)
-        self.assertEqual(editor._windows, [(0L, 0, 5, 0, [(2, 0, 5)], b'blala'), None])
+        self.assertEqual(editor._windows, [(0, 0, 5, 0, [(2, 0, 5)], b'blala'), None])
         self.assertIsInstance(tmpfile, str)
         self.assertEqual(16, len(digest))
 

--- a/subvertpy/tests/test_wc.py
+++ b/subvertpy/tests/test_wc.py
@@ -122,7 +122,7 @@ class AdmTests(SubversionTestCase):
         repos_url = self.make_client("repos", "checkout")
         adm = wc.WorkingCopy(None, "checkout", True)
         adm.add_repos_file("checkout/bar", StringIO("basecontents"), StringIO("contents"), {}, {})
-        self.assertEqual("basecontents", wc.get_pristine_contents("checkout/bar").read())
+        self.assertEqual(b"basecontents", wc.get_pristine_contents("checkout/bar").read())
 
     def test_mark_missing_deleted(self):
         repos_url = self.make_client("repos", "checkout")
@@ -155,7 +155,7 @@ class AdmTests(SubversionTestCase):
         adm = wc.WorkingCopy(None, "checkout", True)
         path = os.path.join(self.test_dir, "checkout/bar")
         stream = adm.translated_stream(path, path, wc.TRANSLATE_TO_NF)
-        self.assertTrue(stream.read().startswith("My id: $Id: "))
+        self.assertTrue(stream.read().startswith(b"My id: $Id: "))
 
     def test_text_modified(self):
         repos_url = self.make_client("repos", "checkout")
@@ -261,7 +261,7 @@ class AdmTests(SubversionTestCase):
                 pass
         editor = Editor()
         (tmpfile, digest) = adm.transmit_text_deltas("bar", True, editor)
-        self.assertEqual(editor._windows, [(0L, 0, 5, 0, [(2, 0, 5)], 'blala'), None])
+        self.assertEqual(editor._windows, [(0L, 0, 5, 0, [(2, 0, 5)], b'blala'), None])
         self.assertIsInstance(tmpfile, str)
         self.assertEqual(16, len(digest))
 

--- a/subvertpy/util.c
+++ b/subvertpy/util.c
@@ -400,11 +400,11 @@ PyObject *pyify_changed_paths(apr_hash_t *changed_paths, bool node_kind, apr_poo
 			 idx = apr_hash_next(idx)) {
 			apr_hash_this(idx, (const void **)&key, &klen, (void **)&val);
 			if (node_kind) {
-				pyval = Py_BuildValue("(czli)", val->action, val->copyfrom_path, 
+				pyval = Py_BuildValue("(Czli)", val->action, val->copyfrom_path, 
 											 val->copyfrom_rev,
 											 svn_node_unknown);
 			} else {
-				pyval = Py_BuildValue("(czl)", val->action, val->copyfrom_path, 
+				pyval = Py_BuildValue("(Czl)", val->action, val->copyfrom_path, 
 											 val->copyfrom_rev);
 			}
 			if (pyval == NULL) {
@@ -449,7 +449,7 @@ PyObject *pyify_changed_paths2(apr_hash_t *changed_paths, apr_pool_t *pool)
 		for (idx = apr_hash_first(pool, changed_paths); idx != NULL;
 			 idx = apr_hash_next(idx)) {
 			apr_hash_this(idx, (const void **)&key, &klen, (void **)&val);
-			pyval = Py_BuildValue("(czli)", val->action, val->copyfrom_path, 
+			pyval = Py_BuildValue("(Czli)", val->action, val->copyfrom_path, 
 										 val->copyfrom_rev, val->node_kind);
 			if (pyval == NULL) {
 				Py_DECREF(py_changed_paths);

--- a/subvertpy/util.c
+++ b/subvertpy/util.c
@@ -725,15 +725,21 @@ static svn_error_t *py_stream_read(void *baton, char *buffer, apr_size_t *length
 
 	if (!PyBytes_Check(ret)) {
 		PyErr_SetString(PyExc_TypeError, "Expected stream read function to return Byte Array");
-		PyGILState_Release(state);
-		return py_svn_error();
+		goto fail;
 	}
-	PyBytes_AsStringAndSize(ret, &data, &sz);
+	if (PyBytes_AsStringAndSize(ret, &data, &sz) < 0) {
+		goto fail;
+	}
 	memcpy(buffer, data, sz);
 	*length = sz;
 	Py_DECREF(ret);
 	PyGILState_Release(state);
 	return NULL;
+	
+fail:
+	Py_DECREF(ret);
+	PyGILState_Release(state);
+	return py_svn_error();
 }
 
 static svn_error_t *py_stream_write(void *baton, const char *data, apr_size_t *len)

--- a/subvertpy/util.c
+++ b/subvertpy/util.c
@@ -376,8 +376,10 @@ apr_hash_t *prop_dict_to_hash(apr_pool_t *pool, PyObject *py_props)
 		if (!string_pmemdup(pool, k, &kbuffer, &ksize)) {
 			return NULL;
 		}
-		val_string = svn_string_ncreate(PyString_AsString(v), 
-										PyString_Size(v), pool);
+		val_string = py_to_svn_string(v, pool);
+		if (val_string == NULL) {
+			return NULL;
+		}
 		
 		apr_hash_set(hash_props, kbuffer, ksize, val_string);
 	}
@@ -432,6 +434,15 @@ char **buffer, apr_ssize_t *size)
 	*size = PyString_GET_SIZE(str);
 	*buffer = apr_pmemdup(pool, *buffer, *size + 1);
 	return true;
+}
+
+svn_string_t *py_to_svn_string(PyObject *obj, apr_pool_t *pool)
+{
+	char *buffer = PyString_AsString(obj);
+	if (buffer == NULL) {
+		return NULL;
+	}
+	return svn_string_ncreate(buffer, PyString_GET_SIZE(obj), pool);
 }
 
 PyObject *pyify_changed_paths(apr_hash_t *changed_paths, bool node_kind, apr_pool_t *pool)

--- a/subvertpy/util.c
+++ b/subvertpy/util.c
@@ -344,6 +344,8 @@ apr_hash_t *prop_dict_to_hash(apr_pool_t *pool, PyObject *py_props)
 {
 	Py_ssize_t idx = 0;
 	PyObject *k, *v;
+	apr_ssize_t ksize;
+	char *kbuffer;
 	apr_hash_t *hash_props;
 	svn_string_t *val_string;
 
@@ -371,10 +373,13 @@ apr_hash_t *prop_dict_to_hash(apr_pool_t *pool, PyObject *py_props)
 			return NULL;
 		}
 
+		if (!string_pmemdup(pool, k, &kbuffer, &ksize)) {
+			return NULL;
+		}
 		val_string = svn_string_ncreate(PyString_AsString(v), 
 										PyString_Size(v), pool);
-		apr_hash_set(hash_props, PyString_AsString(k), 
-					 PyString_Size(k), val_string);
+		
+		apr_hash_set(hash_props, kbuffer, ksize, val_string);
 	}
 
 	return hash_props;
@@ -387,6 +392,21 @@ char *string_pstrdup(apr_pool_t *pool, PyObject *str)
 		return NULL;
 	}
 	return apr_pstrdup(pool, result);
+}
+
+/* Allocate and copy it to an APR pool, making sure it is null terminated.
+This way there are no issues with the original object being freed by Python.
+*/
+bool string_pmemdup(apr_pool_t *pool, PyObject *str,
+char **buffer, apr_ssize_t *size)
+{
+	*buffer = PyString_AsString(str);
+	if (*buffer == NULL) {
+		return false;
+	}
+	*size = PyString_GET_SIZE(str);
+	*buffer = apr_pmemdup(pool, *buffer, *size + 1);
+	return true;
 }
 
 PyObject *pyify_changed_paths(apr_hash_t *changed_paths, bool node_kind, apr_pool_t *pool)

--- a/subvertpy/util.c
+++ b/subvertpy/util.c
@@ -380,6 +380,15 @@ apr_hash_t *prop_dict_to_hash(apr_pool_t *pool, PyObject *py_props)
 	return hash_props;
 }
 
+char *string_pstrdup(apr_pool_t *pool, PyObject *str)
+{
+	char *result = PyString_AsString(str);
+	if (result == NULL) {
+		return NULL;
+	}
+	return apr_pstrdup(pool, result);
+}
+
 PyObject *pyify_changed_paths(apr_hash_t *changed_paths, bool node_kind, apr_pool_t *pool)
 {
 	PyObject *py_changed_paths, *pyval;

--- a/subvertpy/util.c
+++ b/subvertpy/util.c
@@ -414,35 +414,42 @@ apr_hash_t *string_dict_to_hash(apr_pool_t *pool, PyObject *dict)
 
 char *string_pstrdup(apr_pool_t *pool, PyObject *str)
 {
-	char *result = PyString_AsString(str);
-	if (result == NULL) {
+	char *result;
+	str = PyUnicode_AsUTF8String(str);
+	if (str == NULL) {
 		return NULL;
 	}
-	return apr_pstrdup(pool, result);
+	result = apr_pstrdup(pool, PyBytes_AS_STRING(str));
+	Py_DECREF(str);
+	return result;
 }
 
-/* Allocate and copy it to an APR pool, making sure it is null terminated.
-This way there are no issues with the original object being freed by Python.
-*/
+/* Encode a str() object to UTF-8, allocate and copy it to an APR pool,
+making sure it is null terminated. */
 bool string_pmemdup(apr_pool_t *pool, PyObject *str,
 char **buffer, apr_ssize_t *size)
 {
-	*buffer = PyString_AsString(str);
-	if (*buffer == NULL) {
+	str = PyUnicode_AsUTF8String(str);
+	if (str == NULL) {
 		return false;
 	}
-	*size = PyString_GET_SIZE(str);
-	*buffer = apr_pmemdup(pool, *buffer, *size + 1);
+	*size = PyBytes_GET_SIZE(str);
+	*buffer = apr_pmemdup(pool, PyBytes_AS_STRING(str), *size + 1);
+	Py_DECREF(str);
 	return true;
 }
 
 svn_string_t *py_to_svn_string(PyObject *obj, apr_pool_t *pool)
 {
-	char *buffer = PyString_AsString(obj);
-	if (buffer == NULL) {
+	svn_string_t *result;
+	obj = PyUnicode_AsUTF8String(obj);
+	if (obj == NULL) {
 		return NULL;
 	}
-	return svn_string_ncreate(buffer, PyString_GET_SIZE(obj), pool);
+	result = svn_string_ncreate(PyBytes_AS_STRING(obj),
+		PyBytes_GET_SIZE(obj), pool);
+	Py_DECREF(obj);
+	return result;
 }
 
 PyObject *pyify_changed_paths(apr_hash_t *changed_paths, bool node_kind, apr_pool_t *pool)

--- a/subvertpy/util.c
+++ b/subvertpy/util.c
@@ -665,7 +665,7 @@ svn_error_t *py_svn_log_wrapper(void *baton, apr_hash_t *changed_paths, svn_revn
 
 	/*  FIXME: Support including node kind */
 	if (!pyify_log_message(changed_paths, author, date, message, false,
-	pool, &py_changed_paths, &revprops)) {
+			pool, &py_changed_paths, &revprops)) {
 		PyGILState_Release(state);
 		return py_svn_error();
 	}

--- a/subvertpy/util.c
+++ b/subvertpy/util.c
@@ -314,6 +314,10 @@ PyObject *prop_hash_to_dict(apr_hash_t *props)
 			Py_INCREF(py_key);
 		} else {
 			py_key = PyString_FromString(key);
+			if (py_key == NULL) {
+				Py_DECREF(py_val);
+				goto fail_item;
+			}
 		}
 		if (PyDict_SetItem(py_props, py_key, py_val) != 0) {
 			Py_DECREF(py_key);
@@ -488,21 +492,32 @@ PyObject **py_changed_paths, PyObject **revprops)
 	}
 	if (message != NULL) {
 		obj = PyString_FromString(message);
+		if (obj == NULL) {
+			goto fail_props;
+		}
 		PyDict_SetItemString(*revprops, SVN_PROP_REVISION_LOG, obj);
 		Py_DECREF(obj);
 	}
 	if (author != NULL) {
 		obj = PyString_FromString(author);
+		if (obj == NULL) {
+			goto fail_props;
+		}
 		PyDict_SetItemString(*revprops, SVN_PROP_REVISION_AUTHOR, obj);
 		Py_DECREF(obj);
 	}
 	if (date != NULL) {
 		obj = PyString_FromString(date);
+		if (obj == NULL) {
+			goto fail_props;
+		}
 		PyDict_SetItemString(*revprops, SVN_PROP_REVISION_DATE, obj);
 		Py_DECREF(obj);
 	}
 	return true;
 	
+fail_props:
+	Py_DECREF(*revprops);
 fail_dict:
 	Py_DECREF(*py_changed_paths);
 fail:
@@ -700,7 +715,7 @@ PyObject *py_dirent(const svn_dirent_t *dirent, int dirent_fields)
 	PyObject *ret, *obj;
 	ret = PyDict_New();
 	if (ret == NULL)
-		return NULL;
+		goto fail;
 	if (dirent_fields & SVN_DIRENT_KIND) {
 		obj = PyInt_FromLong(dirent->kind);
 		PyDict_SetItemString(ret, "kind", obj);
@@ -729,6 +744,9 @@ PyObject *py_dirent(const svn_dirent_t *dirent, int dirent_fields)
 	if (dirent_fields & SVN_DIRENT_LAST_AUTHOR) {
 		if (dirent->last_author != NULL) {
 			obj = PyString_FromString(dirent->last_author);
+			if (obj == NULL) {
+				goto fail_fields;
+			}
 		} else {
 			obj = Py_None;
 			Py_INCREF(obj);
@@ -737,6 +755,11 @@ PyObject *py_dirent(const svn_dirent_t *dirent, int dirent_fields)
 		Py_DECREF(obj);
 	}
 	return ret;
+	
+fail_fields:
+	Py_DECREF(ret);
+fail:
+	return NULL;
 }
 
 apr_file_t *apr_file_from_object(PyObject *object, apr_pool_t *pool)

--- a/subvertpy/util.h
+++ b/subvertpy/util.h
@@ -47,6 +47,7 @@ __attribute__((warn_unused_result)) apr_pool_t *Pool(apr_pool_t *parent);
 void handle_svn_error(svn_error_t *error);
 bool string_list_to_apr_array(apr_pool_t *pool, PyObject *l, apr_array_header_t **);
 bool path_list_to_apr_array(apr_pool_t *pool, PyObject *l, apr_array_header_t **);
+const char *string_path_canonicalize(PyObject *str, apr_pool_t *pool);
 PyObject *prop_hash_to_dict(apr_hash_t *props);
 apr_hash_t *prop_dict_to_hash(apr_pool_t *pool, PyObject *py_props);
 apr_hash_t *string_dict_to_hash(apr_pool_t *pool, PyObject *dict);

--- a/subvertpy/util.h
+++ b/subvertpy/util.h
@@ -47,12 +47,12 @@ __attribute__((warn_unused_result)) apr_pool_t *Pool(apr_pool_t *parent);
 void handle_svn_error(svn_error_t *error);
 bool string_list_to_apr_array(apr_pool_t *pool, PyObject *l, apr_array_header_t **);
 bool path_list_to_apr_array(apr_pool_t *pool, PyObject *l, apr_array_header_t **);
-const char *string_path_canonicalize(PyObject *str, apr_pool_t *pool);
+const char *string_to_canonical_path(PyObject *str, apr_pool_t *pool);
 PyObject *prop_hash_to_dict(apr_hash_t *props);
 apr_hash_t *prop_dict_to_hash(apr_pool_t *pool, PyObject *py_props);
 apr_hash_t *string_dict_to_hash(apr_pool_t *pool, PyObject *dict);
-char *string_pstrdup(apr_pool_t *pool, PyObject *str);
-bool string_pmemdup(apr_pool_t *pool, PyObject *str,
+char *string_to_utf8(apr_pool_t *pool, PyObject *str);
+bool string_to_utf8_and_size(apr_pool_t *pool, PyObject *str,
 	char **buffer, apr_ssize_t *size);
 svn_string_t *py_to_svn_string(PyObject *obj, apr_pool_t *pool);
 

--- a/subvertpy/util.h
+++ b/subvertpy/util.h
@@ -89,6 +89,9 @@ void PyErr_SetAprStatus(apr_status_t status);
 PyObject *py_dirent(const svn_dirent_t *dirent, int dirent_fields);
 PyObject *PyOS_tmpfile(void);
 PyObject *pyify_changed_paths(apr_hash_t *changed_paths, bool node_kind, apr_pool_t *pool);
+bool pyify_log_message(apr_hash_t *changed_paths, const char *author,
+	const char *date, const char *message, bool node_kind,
+	apr_pool_t *pool, PyObject **py_changed_paths, PyObject **revprops);
 #if ONLY_SINCE_SVN(1, 6)
 PyObject *pyify_changed_paths2(apr_hash_t *changed_paths2, apr_pool_t *pool);
 #endif

--- a/subvertpy/util.h
+++ b/subvertpy/util.h
@@ -53,6 +53,7 @@ apr_hash_t *string_dict_to_hash(apr_pool_t *pool, PyObject *dict);
 char *string_pstrdup(apr_pool_t *pool, PyObject *str);
 bool string_pmemdup(apr_pool_t *pool, PyObject *str,
 	char **buffer, apr_ssize_t *size);
+svn_string_t *py_to_svn_string(PyObject *obj, apr_pool_t *pool);
 
 svn_error_t *py_svn_log_wrapper(void *baton, apr_hash_t *changed_paths, 
 								long revision, const char *author, 

--- a/subvertpy/util.h
+++ b/subvertpy/util.h
@@ -49,6 +49,8 @@ bool string_list_to_apr_array(apr_pool_t *pool, PyObject *l, apr_array_header_t 
 bool path_list_to_apr_array(apr_pool_t *pool, PyObject *l, apr_array_header_t **);
 PyObject *prop_hash_to_dict(apr_hash_t *props);
 apr_hash_t *prop_dict_to_hash(apr_pool_t *pool, PyObject *py_props);
+char *string_pstrdup(apr_pool_t *pool, PyObject *str);
+
 svn_error_t *py_svn_log_wrapper(void *baton, apr_hash_t *changed_paths, 
 								long revision, const char *author, 
 								const char *date, const char *message, 

--- a/subvertpy/util.h
+++ b/subvertpy/util.h
@@ -34,11 +34,6 @@
 
 #define ONLY_BEFORE_SVN(maj, min) (!(ONLY_SINCE_SVN(maj, min)))
 
-/* There's no Py_ssize_t in 2.4, apparently */
-#if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION < 5
-typedef int Py_ssize_t;
-#endif
-
 #ifdef __GNUC__
 #pragma GCC visibility push(hidden)
 #endif

--- a/subvertpy/util.h
+++ b/subvertpy/util.h
@@ -50,6 +50,8 @@ bool path_list_to_apr_array(apr_pool_t *pool, PyObject *l, apr_array_header_t **
 PyObject *prop_hash_to_dict(apr_hash_t *props);
 apr_hash_t *prop_dict_to_hash(apr_pool_t *pool, PyObject *py_props);
 char *string_pstrdup(apr_pool_t *pool, PyObject *str);
+bool string_pmemdup(apr_pool_t *pool, PyObject *str,
+	char **buffer, apr_ssize_t *size);
 
 svn_error_t *py_svn_log_wrapper(void *baton, apr_hash_t *changed_paths, 
 								long revision, const char *author, 

--- a/subvertpy/util.h
+++ b/subvertpy/util.h
@@ -34,6 +34,10 @@
 
 #define ONLY_BEFORE_SVN(maj, min) (!(ONLY_SINCE_SVN(maj, min)))
 
+#if PY_VERSION_HEX < 0x03010000
+#error Python 3.0 is not supported.  Please use 3.1 and higher.
+#endif
+
 #ifdef __GNUC__
 #pragma GCC visibility push(hidden)
 #endif

--- a/subvertpy/util.h
+++ b/subvertpy/util.h
@@ -49,6 +49,7 @@ bool string_list_to_apr_array(apr_pool_t *pool, PyObject *l, apr_array_header_t 
 bool path_list_to_apr_array(apr_pool_t *pool, PyObject *l, apr_array_header_t **);
 PyObject *prop_hash_to_dict(apr_hash_t *props);
 apr_hash_t *prop_dict_to_hash(apr_pool_t *pool, PyObject *py_props);
+apr_hash_t *string_dict_to_hash(apr_pool_t *pool, PyObject *dict);
 char *string_pstrdup(apr_pool_t *pool, PyObject *str);
 bool string_pmemdup(apr_pool_t *pool, PyObject *str,
 	char **buffer, apr_ssize_t *size);

--- a/subvertpy/wc.c
+++ b/subvertpy/wc.c
@@ -39,9 +39,9 @@
 #define REPORTER_T svn_ra_reporter2_t
 #endif
 
-staticforward PyTypeObject Entry_Type;
-staticforward PyTypeObject Status_Type;
-staticforward PyTypeObject Adm_Type;
+static PyTypeObject Entry_Type;
+static PyTypeObject Status_Type;
+static PyTypeObject Adm_Type;
 
 static PyObject *py_entry(const svn_wc_entry_t *entry);
 static PyObject *py_status(const svn_wc_status2_t *status);
@@ -125,7 +125,7 @@ typedef struct {
 	apr_pool_t *pool;
 	svn_wc_committed_queue_t *queue;
 } CommittedQueueObject;
-staticforward PyTypeObject CommittedQueue_Type;
+static PyTypeObject CommittedQueue_Type;
 
 #if ONLY_SINCE_SVN(1, 5)
 static svn_error_t *py_ra_report_set_path(void *baton, const char *path, svn_revnum_t revision, svn_depth_t depth, int start_empty, const char *lock_token, apr_pool_t *pool)
@@ -136,7 +136,7 @@ static svn_error_t *py_ra_report_set_path(void *baton, const char *path, svn_rev
 		py_lock_token = Py_None;
 		Py_INCREF(py_lock_token);
 	} else {
-		py_lock_token = PyString_FromString(lock_token);
+		py_lock_token = PyBytes_FromString(lock_token);
 	}
 	ret = PyObject_CallMethod(self, "set_path", "slbOi", path, revision, start_empty, py_lock_token, depth);
 	Py_DECREF(py_lock_token);
@@ -154,7 +154,7 @@ static svn_error_t *py_ra_report_link_path(void *report_baton, const char *path,
 		py_lock_token = Py_None;
 		Py_INCREF(py_lock_token);
 	} else { 
-		py_lock_token = PyString_FromString(lock_token);
+		py_lock_token = PyBytes_FromString(lock_token);
 	}
 	ret = PyObject_CallMethod(self, "link_path", "sslbOi", path, url, revision, start_empty, py_lock_token, depth);
 	Py_DECREF(py_lock_token);
@@ -174,7 +174,7 @@ static svn_error_t *py_ra_report_set_path(void *baton, const char *path, svn_rev
 		py_lock_token = Py_None;
 		Py_INCREF(py_lock_token);
 	} else {
-		py_lock_token = PyString_FromString(lock_token);
+		py_lock_token = PyBytes_FromString(lock_token);
 	}
 	ret = PyObject_CallMethod(self, "set_path", "slbOi", path, revision, start_empty, py_lock_token, svn_depth_infinity);
 	CB_CHECK_PYRETVAL(ret);
@@ -191,7 +191,7 @@ static svn_error_t *py_ra_report_link_path(void *report_baton, const char *path,
 		py_lock_token = Py_None;
 		Py_INCREF(py_lock_token);
 	} else { 
-		py_lock_token = PyString_FromString(lock_token);
+		py_lock_token = PyBytes_FromString(lock_token);
 	}
 	ret = PyObject_CallMethod(self, "link_path", "sslbOi", path, url, revision, start_empty, py_lock_token, svn_depth_infinity);
 	CB_CHECK_PYRETVAL(ret);
@@ -382,7 +382,7 @@ static PyMemberDef entry_members[] = {
 };
 
 static PyTypeObject Entry_Type = {
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"wc.Entry", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(EntryObject), 
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -493,7 +493,7 @@ static PyMemberDef status_members[] = {
 };
 
 static PyTypeObject Status_Type = {
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"wc.Status", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(StatusObject), 
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -641,7 +641,7 @@ static PyObject *adm_access_path(PyObject *self)
 {
 	AdmObject *admobj = (AdmObject *)self;
 	ADM_CHECK_CLOSED(admobj);
-	return PyString_FromString(svn_wc_adm_access_path(admobj->adm));
+	return PyUnicode_FromString(svn_wc_adm_access_path(admobj->adm));
 }
 
 static PyObject *adm_locked(PyObject *self)
@@ -672,7 +672,7 @@ static PyObject *adm_prop_get(PyObject *self, PyObject *args)
 		ret = Py_None;
 		Py_INCREF(ret);
 	} else {
-		ret = PyString_FromStringAndSize(value->data, value->len);
+		ret = PyUnicode_DecodeUTF8(value->data, value->len, NULL);
 	}
 	apr_pool_destroy(temp_pool);
 	return ret;
@@ -1264,9 +1264,9 @@ static PyObject *adm_repr(PyObject *self)
 	AdmObject *admobj = (AdmObject *)self;
 
 	if (admobj->adm == NULL) {
-		return PyString_FromFormat("<wc.WorkingCopy (closed) at 0x%p>", admobj);
+		return PyUnicode_FromFormat("<wc.WorkingCopy (closed) at 0x%p>", admobj);
 	} else {
-		return PyString_FromFormat("<wc.WorkingCopy at '%s'>", 
+		return PyUnicode_FromFormat("<wc.WorkingCopy at '%s'>", 
 								   svn_wc_adm_access_path(admobj->adm));
 	}
 }
@@ -1742,7 +1742,7 @@ static PyObject *transmit_text_deltas(PyObject *self, PyObject *args)
 			svn_path_canonicalize(path, temp_pool), admobj->adm, fulltext,
 			&py_editor, editor_obj, temp_pool));
 
-	py_digest = PyString_FromStringAndSize((char *)digest, APR_MD5_DIGESTSIZE);
+	py_digest = PyBytes_FromStringAndSize((char *)digest, APR_MD5_DIGESTSIZE);
 	if (py_digest == NULL) {
 		apr_pool_destroy(temp_pool);
 		return NULL;
@@ -2064,7 +2064,7 @@ static PyMethodDef adm_methods[] = {
 	{ "get_ancestry", (PyCFunction)get_ancestry, METH_VARARGS,
 		"S.get_ancestry(path) -> (url, rev)" },
 	{ "maybe_set_repos_root", (PyCFunction)maybe_set_repos_root, METH_VARARGS, "S.maybe_set_repos_root(path, repos)" },
-	{ "add_repos_file", (PyCFunction)add_repos_file, METH_KEYWORDS, 
+	{ "add_repos_file", (PyCFunction)add_repos_file, METH_VARARGS | METH_KEYWORDS, 
 		"S.add_repos_file(dst_path, new_base_contents, new_contents, new_base_props, new_props, copyfrom_url=None, copyfrom_rev=-1, notify_func=None)" },
 	{ "mark_missing_deleted", (PyCFunction)mark_missing_deleted, METH_VARARGS,
 		"S.mark_missing_deleted(path)" },
@@ -2097,7 +2097,7 @@ static PyMethodDef adm_methods[] = {
 };
 
 static PyTypeObject Adm_Type = {
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"wc.WorkingCopy", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(AdmObject), 
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -2176,7 +2176,7 @@ static PyObject *committed_queue_repr(PyObject *self)
 {
 	CommittedQueueObject *cqobj = (CommittedQueueObject *)self;
 
-	return PyString_FromFormat("<wc.CommittedQueue at 0x%p>", cqobj->queue);
+	return PyUnicode_FromFormat("<wc.CommittedQueue at 0x%p>", cqobj->queue);
 }
 
 static PyObject *committed_queue_init(PyTypeObject *self, PyObject *args, PyObject *kwargs)
@@ -2266,7 +2266,7 @@ static PyMethodDef committed_queue_methods[] = {
 };
 
 static PyTypeObject CommittedQueue_Type = {
-	PyObject_HEAD_INIT(NULL) 0,
+	PyVarObject_HEAD_INIT(NULL, 0)
 	"wc.CommittedQueue", /*	const char *tp_name;  For printing, in format "<module>.<name>" */
 	sizeof(CommittedQueueObject), 
 	0,/*	Py_ssize_t tp_basicsize, tp_itemsize;  For allocation */
@@ -2428,7 +2428,7 @@ static PyObject *get_adm_dir(PyObject *self)
 	if (pool == NULL)
 		return NULL;
 	dir = svn_wc_get_adm_dir(pool);
-	ret = PyString_FromString(dir);
+	ret = PyUnicode_FromString(dir);
 	apr_pool_destroy(pool);
 	return ret;
 }
@@ -2466,7 +2466,7 @@ static PyObject *get_pristine_copy_path(PyObject *self, PyObject *args)
 	RUN_SVN_WITH_POOL(pool,
 		  svn_wc_get_pristine_copy_path(svn_path_canonicalize(path, pool),
 										&pristine_path, pool));
-	ret = PyString_FromString(pristine_path);
+	ret = PyUnicode_FromString(pristine_path);
 	apr_pool_destroy(pool);
 	return ret;
 }
@@ -2669,42 +2669,46 @@ static PyMethodDef wc_methods[] = {
 	{ NULL, }
 };
 
-void initwc(void)
+static struct PyModuleDef wc_module = {
+	PyModuleDef_HEAD_INIT, "wc", "Working Copies", -1, wc_methods,
+};
+
+PyMODINIT_FUNC PyInit_wc(void)
 {
-	PyObject *mod;
+	PyObject *mod = NULL;
 
 	if (PyType_Ready(&Entry_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&Status_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&Adm_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&Editor_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&FileEditor_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&DirectoryEditor_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&TxDeltaWindowHandler_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&Stream_Type) < 0)
-		return;
+		return mod;
 
 	if (PyType_Ready(&CommittedQueue_Type) < 0)
-		return;
+		return mod;
 
 	apr_initialize();
 
-	mod = Py_InitModule3("wc", wc_methods, "Working Copies");
+	mod = PyModule_Create(&wc_module);
 	if (mod == NULL)
-		return;
+		return mod;
 
 	PyModule_AddIntConstant(mod, "SCHEDULE_NORMAL", 0);
 	PyModule_AddIntConstant(mod, "SCHEDULE_ADD", 1);
@@ -2770,5 +2774,7 @@ void initwc(void)
 	PyModule_AddObject(mod, "CommittedQueue", (PyObject *)&CommittedQueue_Type);
 	Py_INCREF(&CommittedQueue_Type);
 #endif
+	
+	return mod;
 }
 

--- a/subvertpy/wc.c
+++ b/subvertpy/wc.c
@@ -1149,7 +1149,10 @@ static bool py_dict_to_wcprop_changes(PyObject *dict, apr_pool_t *pool, apr_arra
 		   if (val == Py_None) {
 			   prop->value = NULL;
 		   } else {
-			   prop->value = svn_string_ncreate(PyString_AsString(val), PyString_Size(val), pool);
+			   prop->value = py_to_svn_string(val, pool);
+			   if (prop->value == NULL) {
+				   return false;
+			   }
 		   }
 		   APR_ARRAY_PUSH(*ret, svn_prop_t *) = prop;
 	}

--- a/subvertpy/wc.c
+++ b/subvertpy/wc.c
@@ -1198,11 +1198,7 @@ static PyObject *adm_process_committed(PyObject *self, PyObject *args, PyObject 
 									 &remove_lock, &digest, &digest_len, &remove_changelist))
 		return NULL;
 
-#if PY_VERSION_HEX < 0x02050000
-	PyErr_Warn(PyExc_DeprecationWarning, "process_committed is deprecated. Use process_committed_queue instead.");
-#else
 	PyErr_WarnEx(PyExc_DeprecationWarning, "process_committed is deprecated. Use process_committed_queue instead.", 2);
-#endif
 
 
 	ADM_CHECK_CLOSED(admobj);
@@ -2466,11 +2462,7 @@ static PyObject *get_pristine_copy_path(PyObject *self, PyObject *args)
 	pool = Pool(NULL);
 	if (pool == NULL)
 		return NULL;
-#if PY_VERSION_HEX < 0x02050000
-	PyErr_Warn(PyExc_DeprecationWarning, "get_pristine_copy_path is deprecated. Use get_pristine_contents instead.");
-#else
 	PyErr_WarnEx(PyExc_DeprecationWarning, "get_pristine_copy_path is deprecated. Use get_pristine_contents instead.", 2);
-#endif
 	RUN_SVN_WITH_POOL(pool,
 		  svn_wc_get_pristine_copy_path(svn_path_canonicalize(path, pool),
 										&pristine_path, pool));

--- a/subvertpy/wc.c
+++ b/subvertpy/wc.c
@@ -1142,7 +1142,7 @@ static bool py_dict_to_wcprop_changes(PyObject *dict, apr_pool_t *pool, apr_arra
 
 	while (PyDict_Next(dict, &idx, &key, &val)) {
 		   svn_prop_t *prop = apr_palloc(pool, sizeof(svn_prop_t));
-		   prop->name = string_pstrdup(pool, key);
+		   prop->name = string_to_utf8(pool, key);
 		   if (prop->name == NULL) {
 			   return false;
 		   }

--- a/subvertpy/wc.c
+++ b/subvertpy/wc.c
@@ -1142,7 +1142,10 @@ static bool py_dict_to_wcprop_changes(PyObject *dict, apr_pool_t *pool, apr_arra
 
 	while (PyDict_Next(dict, &idx, &key, &val)) {
 		   svn_prop_t *prop = apr_palloc(pool, sizeof(svn_prop_t));
-		   prop->name = PyString_AsString(key);
+		   prop->name = string_pstrdup(pool, key);
+		   if (prop->name == NULL) {
+			   return false;
+		   }
 		   if (val == Py_None) {
 			   prop->value = NULL;
 		   } else {


### PR DESCRIPTION
Since 1.7, avoiding keyword expansion is a possibility during export.

This opens the call to the new api with that option (false by default).

The test is merely there to ensure the option does not break anything.

api doc: https://subversion.apache.org/docs/api/1.7/group__Export.html#ga012408fea426f8bc283890fdad6f0b1c

Thanks for your time.

Cheers,