### PR TITLE
[python2] Open option ignore_keywords for export operation

### DIFF
--- a/subvertpy/tests/test_client.py
+++ b/subvertpy/tests/test_client.py
@@ -94,6 +94,13 @@ class TestClient(SubversionTestCase):
         self.client.export(self.repos_url, "de")
         self.assertEqual(["foo"], os.listdir("de"))
 
+    def test_export_new_option(self):
+        self.build_tree({"dc/foo": b"bla"})
+        self.client.add("dc/foo")
+        self.client.commit(["dc"])
+        self.client.export(self.repos_url, "de", ignore_externals=True, ignore_keywords=True)
+        self.assertEqual(["foo"], os.listdir("de"))
+
     def test_add_recursive(self):
         self.build_tree({"dc/trunk/foo": 'bla', "dc/trunk": None})
         self.client.add("dc/trunk")


### PR DESCRIPTION
'Symmetric' PR as #24 for python2 - cherry-picked from python3-branch

--

Since 1.7, avoiding keyword expansion is a possibility during export.

This opens the call to the new api with that option (false by default).

The test is merely there to ensure the option does not break anything.

api doc: https://subversion.apache.org/docs/api/1.7/group__Export.html#ga012408fea426f8bc283890fdad6f0b1c

Thanks for your time.

Cheers,
