### PR TITLE
Python 3 does not have tp_print in PyTypeObject

### DIFF
--- a/subvertpy/_ra.c
+++ b/subvertpy/_ra.c
@@ -279,7 +279,7 @@ static PyTypeObject Reporter_Type = {
 	/* Methods to implement standard operations */
 
 	reporter_dealloc, /*	destructor tp_dealloc;	*/
-	NULL, /*	printfunc tp_print;	*/
+	0, /* Py_ssize_t tp_vectorcall_offset; */
 	NULL, /*	getattrfunc tp_getattr;	*/
 	NULL, /*	setattrfunc tp_setattr;	*/
 	NULL, /*	cmpfunc tp_compare;	*/
@@ -2073,7 +2073,7 @@ static PyTypeObject RemoteAccess_Type = {
 	/* Methods to implement standard operations */
 
 	ra_dealloc, /*	destructor tp_dealloc;	*/
-	NULL, /*	printfunc tp_print;	*/
+	0, /* Py_ssize_t tp_vectorcall_offset; */
 	NULL, /*	getattrfunc tp_getattr;	*/
 	NULL, /*	setattrfunc tp_setattr;	*/
 	NULL, /*	cmpfunc tp_compare;	*/
@@ -2397,7 +2397,7 @@ static PyTypeObject Auth_Type = {
 	/* Methods to implement standard operations */
 
 	auth_dealloc, /*	destructor tp_dealloc;	*/
-	NULL, /*	printfunc tp_print;	*/
+	0, /* Py_ssize_t tp_vectorcall_offset; */
 	NULL, /*	getattrfunc tp_getattr;	*/
 	NULL, /*	setattrfunc tp_setattr;	*/
 	NULL, /*	cmpfunc tp_compare;	*/

--- a/subvertpy/client.c
+++ b/subvertpy/client.c
@@ -1616,7 +1616,7 @@ PyTypeObject Config_Type = {
     /* Methods to implement standard operations */
 
     (destructor)config_dealloc, /*    destructor tp_dealloc;    */
-    NULL, /*    printfunc tp_print;    */
+    0, /* Py_ssize_t tp_vectorcall_offset; */
     NULL, /*    getattrfunc tp_getattr;    */
     NULL, /*    setattrfunc tp_setattr;    */
     NULL, /*    cmpfunc tp_compare;    */
@@ -1738,7 +1738,7 @@ PyTypeObject Info_Type = {
     /* Methods to implement standard operations */
 
     info_dealloc, /*    destructor tp_dealloc;  */
-    NULL, /*    printfunc tp_print; */
+    0, /* Py_ssize_t tp_vectorcall_offset; */
     NULL, /*    getattrfunc tp_getattr; */
     NULL, /*    setattrfunc tp_setattr; */
     NULL, /*    cmpfunc tp_compare; */
@@ -1825,7 +1825,7 @@ PyTypeObject WCInfo_Type = {
     /* Methods to implement standard operations */
 
     wcinfo_dealloc, /*    destructor tp_dealloc;  */
-    NULL, /*    printfunc tp_print; */
+    0, /* Py_ssize_t tp_vectorcall_offset; */
     NULL, /*    getattrfunc tp_getattr; */
     NULL, /*    setattrfunc tp_setattr; */
     NULL, /*    cmpfunc tp_compare; */
@@ -1888,7 +1888,7 @@ PyTypeObject Client_Type = {
     /* Methods to implement standard operations */
 
     client_dealloc, /*    destructor tp_dealloc;    */
-    NULL, /*    printfunc tp_print;    */
+    0, /* Py_ssize_t tp_vectorcall_offset; */
     NULL, /*    getattrfunc tp_getattr;    */
     NULL, /*    setattrfunc tp_setattr;    */
     NULL, /*    cmpfunc tp_compare;    */

--- a/subvertpy/editor.c
+++ b/subvertpy/editor.c
@@ -172,7 +172,7 @@ PyTypeObject TxDeltaWindowHandler_Type = {
 	/* Methods to implement standard operations */
 	
 	py_txdelta_window_handler_dealloc, /* destructor tp_dealloc; */
-	NULL, /*	printfunc tp_print;	*/
+	0, /* Py_ssize_t tp_vectorcall_offset; */
 	NULL, /*	getattrfunc tp_getattr;	*/
 	NULL, /*	setattrfunc tp_setattr;	*/
 	NULL, /*	cmpfunc tp_compare;	*/
@@ -310,7 +310,7 @@ PyTypeObject FileEditor_Type = {
 	/* Methods to implement standard operations */
 	
 	py_editor_dealloc, /*	destructor tp_dealloc; 	*/
-	NULL, /*	printfunc tp_print;	*/
+	0, /* Py_ssize_t tp_vectorcall_offset; */
 	NULL, /*	getattrfunc tp_getattr;	*/
 	NULL, /*	setattrfunc tp_setattr;	*/
 	NULL, /*	cmpfunc tp_compare;	*/
@@ -737,7 +737,7 @@ PyTypeObject DirectoryEditor_Type = {
 	/* Methods to implement standard operations */
 
 	py_editor_dealloc, /* destructor tp_dealloc;  */
-	NULL, /*	printfunc tp_print;	*/
+	0, /* Py_ssize_t tp_vectorcall_offset; */
 	NULL, /*	getattrfunc tp_getattr;	*/
 	NULL, /*	setattrfunc tp_setattr;	*/
 	NULL, /*	cmpfunc tp_compare;	*/
@@ -939,7 +939,7 @@ PyTypeObject Editor_Type = {
 	/* Methods to implement standard operations */
 	
 	py_editor_dealloc, /*	destructor tp_dealloc;	*/
-	NULL, /*	printfunc tp_print;	*/
+	0, /* Py_ssize_t tp_vectorcall_offset; */
 	NULL, /*	getattrfunc tp_getattr;	*/
 	NULL, /*	setattrfunc tp_setattr;	*/
 	NULL, /*	cmpfunc tp_compare;	*/

--- a/subvertpy/repos.c
+++ b/subvertpy/repos.c
@@ -278,7 +278,7 @@ PyTypeObject FileSystem_Type = {
 	/* Methods to implement standard operations */
 
 	fs_dealloc, /*	destructor tp_dealloc;	*/
-	NULL, /*	printfunc tp_print;	*/
+	0, /* Py_ssize_t tp_vectorcall_offset; */
 	NULL, /*	getattrfunc tp_getattr;	*/
 	NULL, /*	setattrfunc tp_setattr;	*/
 	NULL, /*	cmpfunc tp_compare;	*/
@@ -545,7 +545,7 @@ PyTypeObject Repository_Type = {
 	/* Methods to implement standard operations */
 
 	repos_dealloc, /*	destructor tp_dealloc;	*/
-	NULL, /*	printfunc tp_print;	*/
+	0, /* Py_ssize_t tp_vectorcall_offset; */
 	NULL, /*	getattrfunc tp_getattr;	*/
 	NULL, /*	setattrfunc tp_setattr;	*/
 	NULL, /*	cmpfunc tp_compare;	*/
@@ -842,7 +842,7 @@ PyTypeObject FileSystemRoot_Type = {
 	/* Methods to implement standard operations */
 
 	fs_root_dealloc, /*	destructor tp_dealloc;	*/
-	NULL, /*	printfunc tp_print;	*/
+	0, /* Py_ssize_t tp_vectorcall_offset; */
 	NULL, /*	getattrfunc tp_getattr;	*/
 	NULL, /*	setattrfunc tp_setattr;	*/
 	NULL, /*	cmpfunc tp_compare;	*/

--- a/subvertpy/wc.c
+++ b/subvertpy/wc.c
@@ -866,7 +866,7 @@ PyTypeObject CommittedQueue_Type = {
 	/* Methods to implement standard operations */
 
 	committed_queue_dealloc, /*	destructor tp_dealloc;	*/
-	NULL, /*	printfunc tp_print;	*/
+	0, /* Py_ssize_t tp_vectorcall_offset; */
 	NULL, /*	getattrfunc tp_getattr;	*/
 	NULL, /*	setattrfunc tp_setattr;	*/
 	NULL, /*	cmpfunc tp_compare;	*/
@@ -1304,7 +1304,7 @@ static PyTypeObject Status3_Type = {
     /* Methods to implement standard operations */
 
     status_dealloc, /*    destructor tp_dealloc;  */
-    NULL, /*    printfunc tp_print; */
+    0, /* Py_ssize_t tp_vectorcall_offset; */
     NULL, /*    getattrfunc tp_getattr; */
     NULL, /*    setattrfunc tp_setattr; */
     NULL, /*    cmpfunc tp_compare; */
@@ -1789,7 +1789,7 @@ static PyTypeObject Context_Type = {
 	/* Methods to implement standard operations */
 
 	context_dealloc, /*	destructor tp_dealloc;	*/
-	NULL, /*	printfunc tp_print;	*/
+	0, /* Py_ssize_t tp_vectorcall_offset; */
 	NULL, /*	getattrfunc tp_getattr;	*/
 	NULL, /*	setattrfunc tp_setattr;	*/
 	NULL, /*	cmpfunc tp_compare;	*/


### PR DESCRIPTION
The the field is called `tp_vectorcall_offset` now, of type `Py_ssize_t`. Current compilers treat using NULL as an integer constant as a type error, so this change fixes a build problem with those compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
