### PR TITLE
Improve unittest calls

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,7 +41,7 @@ class VersionTest(TestCase):
         self.assertEqual(4, len(client.api_version()))
 
     def test_api_version_later_same(self):
-        self.assertTrue(client.api_version() <= client.version())
+        self.assertLessEqual(client.api_version(), client.version())
 
 
 class TestClient(SubversionTestCase):
@@ -120,9 +120,11 @@ class TestClient(SubversionTestCase):
             config = client.get_config(svn_cfg_dir)
             self.assertIsInstance(config, client.Config)
             ignores = config.get_default_ignores()
-            self.assertTrue(
-                base_dir_basename.encode('utf-8') in ignores,
-                f"no {base_dir_basename!r} in {ignores!r}")
+            self.assertIn(
+                base_dir_basename.encode('utf-8'),
+                ignores,
+                f"no {base_dir_basename!r} in {ignores!r}"
+            )
         finally:
             shutil.rmtree(base_dir)
 
@@ -181,7 +183,7 @@ class TestClient(SubversionTestCase):
         actual = datetime.strptime(
             entry["revprops"]["svn:date"].decode('utf-8'),
             "%Y-%m-%dT%H:%M:%S.%fZ")
-        self.assertTrue((actual - expected) < delta)
+        self.assertLess(actual - expected, delta)
 
     def test_log(self):
         log_entries = []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -25,5 +25,7 @@ class TestCore(TestCase):
         super().setUp()
 
     def test_exc(self):
-        self.assertTrue(
-            isinstance(subvertpy.SubversionException("foo", 1), Exception))
+        self.assertIsInstance(
+            subvertpy.SubversionException("foo", 1),
+            Exception
+        )

--- a/tests/test_ra.py
+++ b/tests/test_ra.py
@@ -38,7 +38,7 @@ class VersionTest(TestCase):
         self.assertEqual(4, len(ra.api_version()))
 
     def test_api_version_later_same(self):
-        self.assertTrue(ra.api_version() <= ra.version())
+        self.assertLessEqual(ra.api_version(), ra.version())
 
 
 class TestRemoteAccessUnknown(TestCase):
@@ -159,7 +159,7 @@ class TestRemoteAccess(SubversionTestCase):
     def test_iter_log(self):
         def check_results(returned):
             self.assertEqual(2, len(returned))
-            self.assertTrue(len(returned[0]) in (3, 4))
+            self.assertIn(len(returned[0]), (3, 4))
             if len(returned[0]) == 3:
                 (paths, revnum, props) = returned[0]
             else:
@@ -194,7 +194,7 @@ class TestRemoteAccess(SubversionTestCase):
 
         def check_results(returned):
             self.assertEqual(2, len(returned))
-            self.assertTrue(len(returned[0]) in (3, 4))
+            self.assertIn(len(returned[0]), (3, 4))
             if len(returned[0]) == 3:
                 (paths, revnum, props) = returned[0]
             else:

--- a/tests/test_repos.py
+++ b/tests/test_repos.py
@@ -32,7 +32,7 @@ class VersionTest(TestCase):
         self.assertEqual(4, len(repos.api_version()))
 
     def test_api_version_later_same(self):
-        self.assertTrue(repos.api_version() <= repos.version())
+        self.assertLessEqual(repos.api_version(), repos.version())
 
 
 class TestRepository(TestCaseInTempDir):
@@ -67,8 +67,9 @@ class TestRepository(TestCaseInTempDir):
 
     def test_rev_root(self):
         repos.create(os.path.join(self.test_dir, "foo"))
-        self.assertTrue(
-            repos.Repository("foo").fs().revision_root(0) is not None)
+        self.assertIsNotNone(
+            repos.Repository("foo").fs().revision_root(0)
+        )
 
     def test_load_fs_invalid(self):
         r = repos.create(os.path.join(self.test_dir, "foo"))

--- a/tests/test_wc.py
+++ b/tests/test_wc.py
@@ -33,7 +33,7 @@ class VersionTest(TestCase):
         self.assertEqual(4, len(wc.api_version()))
 
     def test_api_version_later_same(self):
-        self.assertTrue(wc.api_version() <= wc.version())
+        self.assertLessEqual(wc.api_version(), wc.version())
 
 
 class AdmTests(TestCase):


### PR DESCRIPTION
Improve unittest calls

reformatted tests/test_repos.py
reformatted tests/test_wc.py
reformatted tests/test_core.py
reformatted tests/test_ra.py
reformatted tests/test_client.py
All done! 5 reformatted, 5 left unchanged
