### PR TITLE
Build subvertpy abi3 wheels using Python 3.10 limited API

### DIFF
--- a/.github/workflows/macos-wheels.yml
+++ b/.github/workflows/macos-wheels.yml
@@ -2,14 +2,15 @@ name: macos-wheels
 on: [push, pull_request]
 jobs:
   macos:
-    name: subvertpy wheel build for Python ${{ matrix.python-version }}
-      on ${{ matrix.config.os }}
+    name: subvertpy abi3 wheel build on ${{ matrix.config.os }}
     runs-on: ${{ matrix.config.os }}
-    timeout-minutes: 45
+    timeout-minutes: 120
+    env:
+      PY_LIMITED_API: "3.10"
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         config:
           - os: macos-15-intel
             arch: x86_64
@@ -18,11 +19,11 @@ jobs:
     steps:
       - name: Checkout subvertpy code
         uses: actions/checkout@v7
-      - name: Install Python ${{ matrix.python-version }}
+      - name: Install Python ${{ env.PY_LIMITED_API }}
         uses: actions/setup-python@v7
         id: python-install
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PY_LIMITED_API }}
       - name: Install build and pytest Python packages
         run: sudo pip install build pytest
       # sudo is required to restore macports cache, apply same workaround from
@@ -104,7 +105,7 @@ jobs:
           key: macports-cache-${{ matrix.config.arch }}-${{ matrix.config.os }}-${{ steps.cache-key.outputs.value }}
       - name: Sets CIBW_BUILD and SDKROOT environment variable
         env:
-          pyVer: "${{matrix.python-version}}"
+          pyVer: "${{env.PY_LIMITED_API}}"
           arch: "${{matrix.config.arch}}"
         run: |
           echo "CIBW_BUILD=cp${pyVer/./}-macosx_$arch" >> $GITHUB_ENV
@@ -131,8 +132,6 @@ jobs:
           cd ../ && rm -rf subvertpy && python -m pytest tests
       - uses: actions/upload-artifact@v4
         with:
-          name: subvertpy-wheel-macos-${{ matrix.python-version }}-${{ matrix.config.arch }}
+          name: subvertpy-wheel-macos-${{ env.PY_LIMITED_API }}-${{ matrix.config.arch }}
           path: ./wheelhouse/*.whl
-    env:
-      MACOSX_DEPLOYMENT_TARGET: "11.0"
-
+      

--- a/.github/workflows/manylinux-wheels.yml
+++ b/.github/workflows/manylinux-wheels.yml
@@ -2,23 +2,21 @@ name: manylinux-wheels
 on: [push, pull_request]
 jobs:
   manylinux:
-    name: subvertpy manylinux ${{ matrix.python-version }} wheel build
+    name: subvertpy manylinux abi3 wheel build
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    env:
+      PY_LIMITED_API: "3.10"
     steps:
       - name: Checkout subvertpy code
         uses: actions/checkout@v7
-      - name: Install Python ${{ matrix.python-version }}
+      - name: Install Python ${{ env.PY_LIMITED_API }}
         uses: actions/setup-python@v7
         id: python-install
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PY_LIMITED_API }}
       - name: Sets CIBW_BUILD environment variable
         env:
-          pyVer: "${{matrix.python-version}}"
+          pyVer: "${{env.PY_LIMITED_API}}"
         run: |
           echo "CIBW_BUILD=cp${pyVer/./}-manylinux_x86_64" >> $GITHUB_ENV
       - name: Build subvertpy wheel with cibuildwheel
@@ -48,6 +46,6 @@ jobs:
         working-directory: wheelhouse
       - uses: actions/upload-artifact@v4
         with:
-          name: subvertpy-wheel-manylinux-${{ matrix.python-version }}
+          name: subvertpy-wheel-manylinux-${{ env.PY_LIMITED_API }}
           path: ./wheelhouse/*.whl
 

--- a/.github/workflows/windows-wheels.yml
+++ b/.github/workflows/windows-wheels.yml
@@ -2,27 +2,25 @@ name: windows-wheels
 on: [push, pull_request]
 jobs:
   windows:
-    name: subvertpy Python ${{ matrix.python-version }} wheel build on windows
+    name: subvertpy abi3 wheel build on windows
     runs-on: windows-latest
     env:
       VCPKG_INSTALL_DIR: ${{ github.workspace }}\vcpkg\installed\x64-windows-release
+      PY_LIMITED_API: "3.10"
     defaults:
       run:
         shell: cmd
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    
     steps:
       - name: Checkout subvertpy code
         uses: actions/checkout@v7
       - name: Install MSYS2 shell
         uses: msys2/setup-msys2@v2
-      - name: Install Python ${{ matrix.python-version }}
+      - name: Install Python ${{ env.PY_LIMITED_API }}
         uses: actions/setup-python@v7
         id: python-install
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PY_LIMITED_API }}
       - name: Install build, cibuildwheel and pytest Python packages
         run: |
           set PATH=%Python3_ROOT_DIR%\Scripts;%PATH%
@@ -38,7 +36,7 @@ jobs:
           token: ${{ github.token }}
       - name: Sets CIBW_BUILD environment variable
         env:
-          pyVer: "${{matrix.python-version}}"
+          pyVer: "${{env.PY_LIMITED_API}}"
         run: |
           echo "CIBW_BUILD=cp${pyVer/./}-win_amd64" >> $GITHUB_ENV
         shell: msys2 {0}
@@ -126,5 +124,5 @@ jobs:
         shell: msys2 {0}
       - uses: actions/upload-artifact@v4
         with:
-          name: subvertpy-wheel-windows-${{ matrix.python-version }}
+          name: subvertpy-wheel-windows-${{ env.PY_LIMITED_API }}
           path: ./wheelhouse/*.whl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.12.0"
 edition = "2021"
 
 [workspace.dependencies]
-pyo3 = { version = "0.29" }
+pyo3 = { version = "0.29", features = ["abi3-py310"]}
 #subversion = { version = ">=0.0.5" }
 subversion = { version = "0.1.12" }
 #subversion = { path = "../subversion-rs" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,11 +64,11 @@ authors = [{name = "Jelmer Vernooĳ", email = "jelmer@jelmer.uk"}]
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Operating System :: POSIX",
     "Topic :: Software Development :: Version Control",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+py_limited_api=cp310


### PR DESCRIPTION
It allows to build a single binary wheel for subvertpy compatible with any CPython version >= 3.10.

It also drastically reduces the amount of GitHub Actions jobs for generating subvertpy wheels.