### PR TITLE
ci: Fix wheel builds

### DIFF
--- a/.github/workflows/macos-wheels.yml
+++ b/.github/workflows/macos-wheels.yml
@@ -5,7 +5,7 @@ jobs:
     name: subvertpy wheel build for Python ${{ matrix.python-version }}
       on ${{ matrix.config.os }}
     runs-on: ${{ matrix.config.os }}
-    timeout-minutes: 45
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -126,7 +126,7 @@ jobs:
           python -c "
           from subvertpy import client, ra, repos, subr, wc;
           client = client.Client(auth=ra.Auth([ra.get_username_provider()]));
-          client.info('https://svn.pld-linux.org/svn')"
+          client.info('https://svn.apache.org/repos/asf')"
 
           cd ../ && rm -rf subvertpy && python -m pytest tests
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/manylinux-wheels.yml
+++ b/.github/workflows/manylinux-wheels.yml
@@ -41,7 +41,7 @@ jobs:
           $Python3_ROOT_DIR/bin/python -c "
           from subvertpy import client, ra, repos, subr, wc;
           client = client.Client(auth=ra.Auth([ra.get_username_provider()]));
-          client.info('https://svn.pld-linux.org/svn')"
+          client.info('https://svn.apache.org/repos/asf')"
 
           pip3 install pytest
           cd ../ && rm -rf subvertpy && python3 -m pytest tests

--- a/.github/workflows/windows-wheels.yml
+++ b/.github/workflows/windows-wheels.yml
@@ -119,7 +119,7 @@ jobs:
           python -c "
           from subvertpy import client, ra, repos, subr, wc;
           client = client.Client(auth=ra.Auth([ra.get_username_provider()]));
-          client.info('https://svn.pld-linux.org/svn')"
+          client.info('https://svn.apache.org/repos/asf')"
 
           pip install pytest
           cd ../ && rm -rf subvertpy && python -m pytest tests


### PR DESCRIPTION
Raise macos-wheels job timeout to 120 minutes: macos-15-intel builds of the SVN dep stack take ~1h30m in practice and were hitting the 45m cap on every run.
